### PR TITLE
Fix bug of PMP check

### DIFF
--- a/benchmarks/pmp/pmp.c
+++ b/benchmarks/pmp/pmp.c
@@ -94,7 +94,7 @@ INLINE int pmp_ok(pmpcfg_t p, uintptr_t addr, uintptr_t size)
       hits += granule;
   }
 
-  return hits == 0 || hits >= size;
+  return hits != 0 && hits >= size;
 }
 
 INLINE void test_one(uintptr_t addr, uintptr_t size)
@@ -117,9 +117,9 @@ INLINE void test_all_sizes(pmpcfg_t p, uintptr_t addr)
     if (addr & (size - 1))
       continue;
     trap_expected = !pmp_ok(p, addr, size);
-    test_one(addr, size);
     if (trap_expected)
       exit(2);
+    test_one(addr, size);
   }
 }
 


### PR DESCRIPTION
Hey, I find a bug of PMP check when I try to modify PMP benchmark.
![image](https://user-images.githubusercontent.com/41533488/106884275-0b399380-671c-11eb-886f-3baad0715480.png)

First, I think only when `hits !=0 && hits >= size`, access will be allowed.
Sencond,  `testone` func should not execute when trap_expected == 1.

Thanks!