### PR TITLE
Remove slen.

### DIFF
--- a/debug/targets/RISC-V/spike-multi.py
+++ b/debug/targets/RISC-V/spike-multi.py
@@ -19,13 +19,11 @@ class multispike(targets.Target):
     support_memory_sampling = False # Needs SBA
 
     def create(self):
-        # TODO: It would be nice to test with slen=128, but spike currently
-        # requires vlen==slen.
         return testlib.MultiSpike(
             [
                 testlib.Spike(self, isa="RV64IMAFDV",
                     support_hasel=False, support_abstract_csr=False,
-                    vlen=512, elen=64, slen=512, harts=self.harts[2:]),
+                    vlen=512, elen=64, harts=self.harts[2:]),
                 testlib.Spike(self, isa="RV32IMAFDCV",
                     support_abstract_csr=True, support_haltgroups=False,
                     # elen must be at least 64 because D is supported.

--- a/debug/targets/RISC-V/spike64-2-hwthread.py
+++ b/debug/targets/RISC-V/spike64-2-hwthread.py
@@ -4,12 +4,17 @@ import testlib
 import spike64  # pylint: disable=import-error
 
 class spike64_2(targets.Target):
-    harts = [spike64.spike64_hart(misa=0x8000000000141129),
-            spike64.spike64_hart(misa=0x8000000000141129)]
+    harts = [spike64.spike64_hart(misa=0x8000000000341129),
+            spike64.spike64_hart(misa=0x8000000000341129)]
     openocd_config_path = "spike-2-hwthread.cfg"
-    timeout_sec = 5
+    # Increased timeout because we use abstract_rti to artificially slow things
+    # down.
+    timeout_sec = 20
     implements_custom_test = True
+    support_hasel = False
     support_memory_sampling = False # Needs SBA
 
     def create(self):
-        return testlib.Spike(self)
+        return testlib.Spike(self, isa="RV64IMAFDV", abstract_rti=30,
+                support_hasel=False, support_abstract_csr=False,
+                vlen=512, elen=64)

--- a/debug/targets/RISC-V/spike64-2.py
+++ b/debug/targets/RISC-V/spike64-2.py
@@ -4,19 +4,12 @@ import testlib
 import spike64  # pylint: disable=import-error
 
 class spike64_2(targets.Target):
-    harts = [spike64.spike64_hart(misa=0x8000000000341129),
-            spike64.spike64_hart(misa=0x8000000000341129)]
+    harts = [spike64.spike64_hart(misa=0x8000000000141129),
+            spike64.spike64_hart(misa=0x8000000000141129)]
     openocd_config_path = "spike-2.cfg"
-    # Increased timeout because we use abstract_rti to artificially slow things
-    # down.
-    timeout_sec = 20
+    timeout_sec = 5
     implements_custom_test = True
-    support_hasel = False
     support_memory_sampling = False # Needs SBA
 
     def create(self):
-        # TODO: It would be nice to test with slen=128, but spike currently
-        # requires vlen==slen.
-        return testlib.Spike(self, isa="RV64IMAFDV", abstract_rti=30,
-                support_hasel=False, support_abstract_csr=False,
-                vlen=512, elen=64, slen=512)
+        return testlib.Spike(self)

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -65,7 +65,7 @@ class Spike:
     def __init__(self, target, halted=False, timeout=None, with_jtag_gdb=True,
             isa=None, progbufsize=None, dmi_rti=None, abstract_rti=None,
             support_hasel=True, support_abstract_csr=True,
-            support_haltgroups=True, vlen=128, elen=64, slen=128, harts=None):
+            support_haltgroups=True, vlen=128, elen=64, harts=None):
         """Launch spike. Return tuple of its process and the port it's running
         on."""
         self.process = None
@@ -78,7 +78,6 @@ class Spike:
         self.support_haltgroups = support_haltgroups
         self.vlen = vlen
         self.elen = elen
-        self.slen = slen
 
         self.harts = harts or target.harts or [target]
 
@@ -154,8 +153,7 @@ class Spike:
             cmd.append("--dm-no-halt-groups")
 
         if 'V' in isa[2:]:
-            cmd.append("--varch=vlen:%d,elen:%d,slen:%d" % (self.vlen,
-                self.elen, self.slen))
+            cmd.append("--varch=vlen:%d,elen:%d" % (self.vlen, self.elen))
 
         assert len(set(t.ram for t in self.harts)) == 1, \
                 "All spike harts must have the same RAM layout"


### PR DESCRIPTION
It's not an argument to spike anymore.

Also switch testing the vector unit from multi-gdb to `-rtos hwthread`.
This exposes a bug in OpenOCD (which is already fixed).