### PR TITLE
Set `riscv resume_order reversed`.

### DIFF
--- a/debug/targets/RISC-V/spike-2-hwthread.cfg
+++ b/debug/targets/RISC-V/spike-2-hwthread.cfg
@@ -25,6 +25,8 @@ foreach t [target names] {
     riscv expose_custom 1,12345-12348
 }
 
+riscv resume_order reversed
+
 init
 
 set challenge [riscv authdata_read]


### PR DESCRIPTION
The tests don't confirm that the order actually changes, but at least
the code that does the work now is executed during the tests.