### PR TITLE
With new OpenOCD, gdb prints thread info differently

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -870,7 +870,8 @@ class Gdb:
         for line in output.splitlines():
             m = re.match(
                     r"[\s\*]*(\d+)\s*"
-                    r"(Remote target|Thread (\d+)\s*\(Name: ([^\)]+))"
+                    r'(Remote target'
+                    r'|Thread (\d+)\s*(?:".*?")?\s*\(Name: ([^\)]+))'
                     r"\s*(.*)", line)
             if m:
                 threads.append(Thread(*m.groups()))


### PR DESCRIPTION
It includes the name in quotes:
```* 2    Thread 1 "Current Execution" (Name: Current Execution) 0x10000100 in main```

Just ignore that part.