### PR TITLE
Loosen failing store-conditional test

### DIFF
--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -8,7 +8,8 @@
 # Helper macros
 #-----------------------------------------------------------------------
 
-#define MASK_XLEN(x) ((x) & ((1 << (__riscv_xlen - 1) << 1) - 1))
+#define XLEN_MASK ((1 << (__riscv_xlen - 1) << 1) - 1)
+#define MASK_XLEN(x) ((x) & (XLEN_MASK))
 
 #define TEST_CASE( testnum, testreg, correctval, code... ) \
 test_ ## testnum: \
@@ -16,6 +17,15 @@ test_ ## testnum: \
     li  x7, MASK_XLEN(correctval); \
     li  TESTNUM, testnum; \
     bne testreg, x7, fail;
+
+#define TEST_CASE_NEQ( testnum, testreg, wrongval, code... ) \
+test_ ## testnum: \
+    code; \
+    andi testreg, testreg, XLEN_MASK; \
+    li   x7, MASK_XLEN(wrongval); \
+    li   TESTNUM, testnum; \
+    beq  testreg, x7, fail;
+
 
 # We use a macro hack to simpify code generation for various numbers
 # of bubble cycles.

--- a/isa/rv64ua/lrsc.S
+++ b/isa/rv64ua/lrsc.S
@@ -26,7 +26,7 @@ bgeu a2, a3, 1b
 bltu a1, a3, 1b
 
 # make sure that sc without a reservation fails.
-TEST_CASE( 2, a4, 1, \
+TEST_CASE_NEQ( 2, a4, 0, \
   la a0, foo; \
   li a5, 0xdeadbeef; \
   sc.w a4, a5, (a0); \


### PR DESCRIPTION
The ISA specification mandates that:
> If the SC.W fails, the instruction does not write to memory, and it writes a
nonzero value to rd.

Test 2 in `rv64ua-p-lrsc` however checks that the return value is exactly 1.
https://github.com/riscv-software-src/riscv-tests/blob/3e2bf06b071a77ae62c09bf07c5229d1f9397d94/isa/rv64ua/lrsc.S#L28-L33

This PR proposes to loosen the constraint by checking not equivalency to 1, but rather inequality to 0.
This allows cores implementing the looser option, while complying to the specification, to make use of the `riscv-tests` suite.

A notable example being the CVA6 core [failing](https://github.com/openhwgroup/cva6/pull/838) on this test after recent changes.