### PR TITLE
Test semihosting_fileio

### DIFF
--- a/debug/programs/semihosting.c
+++ b/debug/programs/semihosting.c
@@ -65,9 +65,11 @@ int main()
 {
     char *filename = NULL;
     const char *message = "Hello, world!\n";
+    const char *message2 = "Do re mi fa so la ti do!\n";
     int fd;
 
 begin:
     fd = open(filename, O_WRONLY, 0644);
     write(fd, message, strlen(message));
+    write(1, message2, strlen(message2));
 }


### PR DESCRIPTION
In the original test, confirm that stdout data ends up in the OpenOCD
log.
In the new test, with `arm semihosting_fileio` enabled, confirm that
stdout data ends up in gdb's CLI.

This test requires https://github.com/riscv/riscv-openocd/pull/699.