### PR TITLE
Fix GdbTest.disable_pmp failing on systems which support NAPOT but not TOR regions

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1208,8 +1208,14 @@ class GdbTest(BaseTest):
         # memory.
         try:
             self.gdb.p("$pmpcfg0=0xf")  # TOR, R, W, X
-            self.gdb.p("$pmpaddr0=0x%x" %
-                    ((self.hart.ram + self.hart.ram_size) >> 2))
+            if self.gdb.p("$pmpcfg0") != 0xf:
+                # TOR is unsupported (detected via WARL) so use NAPOT instead
+                self.gdb.p("$pmpcfg0=0x1f") # NAPOT, R, W, X
+                self.gdb.p("$pmpaddr0=0x" + "f" * (self.hart.xlen // 4))
+            else:
+                # pmcfg0 readback matches write, so TOR is supported.
+                self.gdb.p("$pmpaddr0=0x%x" %
+                        ((self.hart.ram + self.hart.ram_size) >> 2))
         except CouldNotFetch:
             # PMP registers are optional
             pass


### PR DESCRIPTION
`GdbTest.disable_pmp` fails on systems which have a PMP but do not implement the TOR region type. This leaves memory inaccessible to U-mode, which then causes the `PrivRw` test to fail, because attempting to single-step in U-mode causes a trap to M-mode.

This patch reads back `pmpcfg0` after writing, to check if the implementation has WARL'd the A field to some other value. If this is the case, it attempts to use an NAPOT region covering all physical memory instead.