### PR TITLE
Permit mtval to be zero in misaligned address test, fixes #389

### DIFF
--- a/isa/rv64mi/ma_addr.S
+++ b/isa/rv64mi/ma_addr.S
@@ -99,10 +99,12 @@ mtvec_handler:
   bne t0, s1, fail
 
   csrr t0, mbadaddr
+  beqz t0, 1f
   bne t0, t1, fail
 
   lb t0, (t0)
   beqz t0, fail
+1:
 
   csrw mepc, t2
   mret


### PR DESCRIPTION
See discussion on #389 