### PR TITLE
Test misaligned stores

### DIFF
--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -217,6 +217,7 @@ test_ ## testnum: \
 
 #define TEST_LD_OP( testnum, inst, result, offset, base ) \
     TEST_CASE( testnum, x14, result, \
+      li  x15, result; /* Tell the exception handler the expected result. */ \
       la  x1, base; \
       inst x14, offset(x1); \
     )
@@ -700,6 +701,21 @@ test_ ## testnum: \
     .popsection
 
 // ^ x14 is used in some other macros, to avoid issues we use x15 for upper word
+
+#define MISALIGNED_LOAD_HANDLER \
+  li t0, CAUSE_MISALIGNED_LOAD; \
+  csrr t1, mcause; \
+  bne t0, t1, fail; \
+  \
+  /* We got a misaligned exception. Pretend we handled it in software */ \
+  /* by loading the correct result here. */ \
+  mv  a4, a5; \
+  \
+  /* And skip this instruction */ \
+  csrr t0, mepc; \
+  addi t0, t0, 4; \
+  csrw mepc, t0; \
+  mret
 
 #-----------------------------------------------------------------------
 # Pass and fail code (assumes test num is in TESTNUM)

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -12,9 +12,9 @@
 
 #define TEST_CASE( testnum, testreg, correctval, code... ) \
 test_ ## testnum: \
+    li  TESTNUM, testnum; \
     code; \
     li  x7, MASK_XLEN(correctval); \
-    li  TESTNUM, testnum; \
     bne testreg, x7, fail;
 
 # We use a macro hack to simpify code generation for various numbers

--- a/isa/rv32mi/Makefrag
+++ b/isa/rv32mi/Makefrag
@@ -12,5 +12,7 @@ rv32mi_sc_tests = \
 	scall \
 	sbreak \
 	shamt \
+        lw-misaligned \
+        lh-misaligned \
 
 rv32mi_p_tests = $(addprefix rv32mi-p-, $(rv32mi_sc_tests))

--- a/isa/rv32mi/lh-misaligned.S
+++ b/isa/rv32mi/lh-misaligned.S
@@ -1,0 +1,8 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64M
+#define RVTEST_RV64M RVTEST_RV32M
+#define __MACHINE_MODE
+
+#include "../rv64mi/lh-misaligned.S"

--- a/isa/rv32mi/lw-misaligned.S
+++ b/isa/rv32mi/lw-misaligned.S
@@ -1,0 +1,8 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64M
+#define RVTEST_RV64M RVTEST_RV32M
+#define __MACHINE_MODE
+
+#include "../rv64mi/lw-misaligned.S"

--- a/isa/rv32mi/shamt.S
+++ b/isa/rv32mi/shamt.S
@@ -25,8 +25,7 @@ RVTEST_CODE_BEGIN
 .global mtvec_handler
 mtvec_handler:
   # Trapping on test 3 is good.
-  # Note that since the test didn't complete, TESTNUM is smaller by 1.
-  li t0, 2
+  li t0, 3
   bne TESTNUM, t0, fail
 
   # Make sure CAUSE indicates an illegal instructino.

--- a/isa/rv64mi/Makefrag
+++ b/isa/rv64mi/Makefrag
@@ -12,5 +12,8 @@ rv64mi_sc_tests = \
 	ma_addr \
 	scall \
 	sbreak \
+        ld-misaligned \
+        lw-misaligned \
+        lh-misaligned \
 
 rv64mi_p_tests = $(addprefix rv64mi-p-, $(rv64mi_sc_tests))

--- a/isa/rv64mi/ld-misaligned.S
+++ b/isa/rv64mi/ld-misaligned.S
@@ -1,0 +1,45 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lw-unaligned.S
+#-----------------------------------------------------------------------------
+#
+# Test that misaligned loads work or raise the correct exception
+# This test assumes the target is little-endian
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  TEST_LD_OP( 2, ld, 0x0807060504030201, 0, tdat );
+  TEST_LD_OP( 3, ld, 0x0908070605040302, 1, tdat );
+  TEST_LD_OP( 4, ld, 0x0a09080706050403, 2, tdat );
+  TEST_LD_OP( 5, ld, 0x0b0a090807060504, 3, tdat );
+  TEST_LD_OP( 6, ld, 0x0c0b0a0908070605, 4, tdat );
+  TEST_LD_OP( 7, ld, 0x0d0c0b0a09080706, 5, tdat );
+  TEST_LD_OP( 8, ld, 0x0e0d0c0b0a090807, 6, tdat );
+  TEST_LD_OP( 9, ld, 0x0f0e0d0c0b0a0908, 7, tdat );
+
+2:
+  TEST_PASSFAIL
+
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  MISALIGNED_LOAD_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+    .byte 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+    .byte 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10
+
+RVTEST_DATA_END

--- a/isa/rv64mi/lh-misaligned.S
+++ b/isa/rv64mi/lh-misaligned.S
@@ -1,0 +1,38 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lh-unaligned.S
+#-----------------------------------------------------------------------------
+#
+# Test that misaligned loads work or raise the correct exception
+# This test assumes the target is little-endian
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  TEST_LD_OP( 2, lh, 0x0201, 0,  tdat );
+  TEST_LD_OP( 3, lh, 0x0302, 1,  tdat );
+
+2:
+  TEST_PASSFAIL
+
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  MISALIGNED_LOAD_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+    .byte 0x01, 0x02, 0x03, 0x04
+
+RVTEST_DATA_END

--- a/isa/rv64mi/lw-misaligned.S
+++ b/isa/rv64mi/lw-misaligned.S
@@ -1,0 +1,40 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lw-unaligned.S
+#-----------------------------------------------------------------------------
+#
+# Test that misaligned loads work or raise the correct exception
+# This test assumes the target is little-endian
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  TEST_LD_OP( 2, lw, 0x04030201, 0,  tdat );
+  TEST_LD_OP( 3, lw, 0x05040302, 1,  tdat );
+  TEST_LD_OP( 4, lw, 0x06050403, 2,  tdat );
+  TEST_LD_OP( 5, lw, 0x07060504, 3, tdat );
+
+2:
+  TEST_PASSFAIL
+
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  MISALIGNED_LOAD_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+    .byte 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+
+RVTEST_DATA_END

--- a/isa/rv64si/csr.S
+++ b/isa/rv64si/csr.S
@@ -142,10 +142,9 @@ finish:
   .global stvec_handler
 stvec_handler:
   # Trapping on tests 13-15 is good news.
-  # Note that since the test didn't complete, TESTNUM is smaller by 1.
-  li t0, 12
+  li t0, 13
   bltu TESTNUM, t0, 1f
-  li t0, 14
+  li t0, 15
   bleu TESTNUM, t0, privileged
 1:
 


### PR DESCRIPTION
This passes `make -C isa run` against spike built with and without `--enable-misaligned`.

If this organization is good, I'll do something similar for stores.