### PR TITLE
Test misaligned stores.

### DIFF
--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -226,8 +226,14 @@ test_ ## testnum: \
     TEST_CASE( testnum, x14, result, \
       la  x1, base; \
       li  x2, result; \
+      la  x15, 7f; /* Tell the exception handler how to skip this test. */ \
       store_inst x2, offset(x1); \
       load_inst x14, offset(x1); \
+      j 8f; \
+7:    \
+      /* Set up the correct result for TEST_CASE(). */ \
+      mv x14, x2; \
+8:    \
     )
 
 #define TEST_LD_DEST_BYPASS( testnum, nop_cycles, inst, result, offset, base ) \
@@ -715,6 +721,15 @@ test_ ## testnum: \
   csrr t0, mepc; \
   addi t0, t0, 4; \
   csrw mepc, t0; \
+  mret
+
+#define MISALIGNED_STORE_HANDLER \
+  li t0, CAUSE_MISALIGNED_STORE; \
+  csrr t1, mcause; \
+  bne t0, t1, fail; \
+  \
+  /* We got a misaligned exception. Skip this test. */ \
+  csrw mepc, x15; \
   mret
 
 #-----------------------------------------------------------------------

--- a/isa/rv32mi/Makefrag
+++ b/isa/rv32mi/Makefrag
@@ -14,5 +14,7 @@ rv32mi_sc_tests = \
 	shamt \
         lw-misaligned \
         lh-misaligned \
+	sh-misaligned \
+	sw-misaligned \
 
 rv32mi_p_tests = $(addprefix rv32mi-p-, $(rv32mi_sc_tests))

--- a/isa/rv32mi/sh-misaligned.S
+++ b/isa/rv32mi/sh-misaligned.S
@@ -1,0 +1,8 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64M
+#define RVTEST_RV64M RVTEST_RV32M
+#define __MACHINE_MODE
+
+#include "../rv64mi/sh-misaligned.S"

--- a/isa/rv32mi/sw-misaligned.S
+++ b/isa/rv32mi/sw-misaligned.S
@@ -1,0 +1,8 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64M
+#define RVTEST_RV64M RVTEST_RV32M
+#define __MACHINE_MODE
+
+#include "../rv64mi/sw-misaligned.S"

--- a/isa/rv64mi/Makefrag
+++ b/isa/rv64mi/Makefrag
@@ -15,5 +15,8 @@ rv64mi_sc_tests = \
         ld-misaligned \
         lw-misaligned \
         lh-misaligned \
+        sh-misaligned \
+        sw-misaligned \
+        sd-misaligned \
 
 rv64mi_p_tests = $(addprefix rv64mi-p-, $(rv64mi_sc_tests))

--- a/isa/rv64mi/sd-misaligned.S
+++ b/isa/rv64mi/sd-misaligned.S
@@ -1,0 +1,44 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sd-unaligned.S
+#-----------------------------------------------------------------------------
+#
+# Test that misaligned stores work or raise the correct exception
+# This test assumes the target is little-endian
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  TEST_ST_OP( 2, ld, sd, 0x0102030405060708, 0, tdat );
+  TEST_ST_OP( 3, ld, sd, 0x090a0b0c0d0e0f10, 1, tdat );
+  TEST_ST_OP( 4, ld, sd, 0x1112131415161718, 2, tdat );
+  TEST_ST_OP( 5, ld, sd, 0x191a1b1c1d1e1f20, 3, tdat );
+  TEST_ST_OP( 6, ld, sd, 0x2122232425262728, 4, tdat );
+  TEST_ST_OP( 7, ld, sd, 0x292a2b2c2d2e2f30, 5, tdat );
+  TEST_ST_OP( 8, ld, sd, 0x3132333435363738, 6, tdat );
+  TEST_ST_OP( 9, ld, sd, 0x393a3b3c3d3e3f40, 7, tdat );
+
+2:
+  TEST_PASSFAIL
+
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  MISALIGNED_STORE_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+    .zero 16
+
+RVTEST_DATA_END

--- a/isa/rv64mi/sh-misaligned.S
+++ b/isa/rv64mi/sh-misaligned.S
@@ -1,0 +1,38 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sh-unaligned.S
+#-----------------------------------------------------------------------------
+#
+# Test that misaligned stores work or raise the correct exception
+# This test assumes the target is little-endian
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  TEST_ST_OP( 2, lh, sh, 0x1234, 0, tdat );
+  TEST_ST_OP( 3, lh, sh, 0x5678, 1, tdat );
+
+2:
+  TEST_PASSFAIL
+
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  MISALIGNED_STORE_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+    .zero 4
+
+RVTEST_DATA_END

--- a/isa/rv64mi/sw-misaligned.S
+++ b/isa/rv64mi/sw-misaligned.S
@@ -1,0 +1,40 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sw-unaligned.S
+#-----------------------------------------------------------------------------
+#
+# Test that misaligned stores work or raise the correct exception
+# This test assumes the target is little-endian
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  TEST_ST_OP( 2, lw, sw, 0x12345678, 0, tdat );
+  TEST_ST_OP( 3, lw, sw, 0xffffffff9abcdef0, 1, tdat );
+  TEST_ST_OP( 4, lw, sw, 0xffffffffdeadbeef, 2, tdat );
+  TEST_ST_OP( 5, lw, sw, 0xfffffffffeed0011, 3, tdat );
+
+2:
+  TEST_PASSFAIL
+
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  MISALIGNED_STORE_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+    .zero 8
+
+RVTEST_DATA_END


### PR DESCRIPTION
Assume that misaligned loads work correctly.

Passes `make -C isa run` against spike (both with and without misaligned
support).