### PR TITLE
Fix SemihostingFileio

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -972,7 +972,8 @@ class Semihosting(GdbSingleHartTest):
 
 class SemihostingFileio(Semihosting):
     def setup(self):
-        self.gdb.command("monitor arm semihosting_fileio enable")
+        self.gdb.command("monitor foreach t [target names] { "
+            "targets $t; arm semihosting_fileio enable }")
         super().setup()
 
     def test(self):


### PR DESCRIPTION
Turn semihosting_fileio on for every hart. This test still fails if it
ends up running on hart 1 instead of 0, but at least it's closer to
passing. Feels like the remaining problem is in OpenOCD.