### PR TITLE
Ignore `mip` and `time` in DisconnectTest.

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -419,7 +419,8 @@ class DisconnectTest(GdbTest):
 
         regnames = set(old_values.keys()).union(set(new_values.keys()))
         for regname in regnames:
-            if regname in ("mcycle", "minstret", "instret", "cycle"):
+            if regname in ("mcycle", "minstret", "instret", "cycle", "mip",
+                    "time"):
                 continue
             assertEqual(old_values[regname], new_values[regname],
                     f"Register {regname} didn't match")


### PR DESCRIPTION
These can change at any time and that is OK.