### PR TITLE
fix compile for Clang

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -38,8 +38,8 @@ bmarks = \
 RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
 RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns
-RISCV_LINK ?= $(RISCV_GCC) -T $(src_dir)/common/test.ld $(incs)
-RISCV_LINK_OPTS ?= -static -nostdlib -nostartfiles -lm -lgcc -T $(src_dir)/common/test.ld
+RISCV_LINK ?= $(RISCV_GCC) -Wl,-T,$(src_dir)/common/test.ld $(incs)
+RISCV_LINK_OPTS ?= -static -nostdlib -nostartfiles -lm -lgcc -Wl,-T,$(src_dir)/common/test.ld
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data
 RISCV_SIM ?= spike --isa=rv$(XLEN)gc
 

--- a/benchmarks/common/syscalls.c
+++ b/benchmarks/common/syscalls.c
@@ -93,9 +93,11 @@ int __attribute__((weak)) main(int argc, char** argv)
   return -1;
 }
 
+// Must be global for compatibility with Clang
+register void* thread_pointer asm("tp");
+
 static void init_tls()
 {
-  register void* thread_pointer asm("tp");
   extern char _tdata_begin, _tdata_end, _tbss_end;
   size_t tdata_size = &_tdata_end - &_tdata_begin;
   memcpy(thread_pointer, &_tdata_begin, tdata_size);

--- a/benchmarks/common/syscalls.c
+++ b/benchmarks/common/syscalls.c
@@ -356,18 +356,18 @@ int printf(const char* fmt, ...)
   return 0; // incorrect return value, but who cares, anyway?
 }
 
+static void sprintf_putch(int ch, void** data)
+{
+  char** pstr = (char**)data;
+  **pstr = ch;
+  (*pstr)++;
+}
+
 int sprintf(char* str, const char* fmt, ...)
 {
   va_list ap;
   char* str0 = str;
   va_start(ap, fmt);
-
-  void sprintf_putch(int ch, void** data)
-  {
-    char** pstr = (char**)data;
-    **pstr = ch;
-    (*pstr)++;
-  }
 
   vprintfmt(sprintf_putch, (void**)&str, fmt, ap);
   *str = 0;

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -397,6 +397,7 @@ test_ ## testnum: \
 #define sNaN 9218868437227405313    // 7ff0000000000001
 #endif
 
+#ifdef __GNU__
 #define TEST_FP_OP_H_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
 test_ ## testnum: \
   li  TESTNUM, testnum; \
@@ -418,6 +419,29 @@ test_ ## testnum: \
   .float16 val3; \
   .result; \
   .popsection
+#else
+#define TEST_FP_OP_H_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
+test_ ## testnum: \
+  li  TESTNUM, testnum; \
+  la  a0, test_ ## testnum ## _data ;\
+  flh f0, 0(a0); \
+  flh f1, 2(a0); \
+  flh f2, 4(a0); \
+  lh  a3, 6(a0); \
+  code; \
+  fsflags a1, x0; \
+  li a2, flags; \
+  bne a0, a3, fail; \
+  bne a1, a2, fail; \
+  .pushsection .data; \
+  .align 1; \
+  test_ ## testnum ## _data: \
+  .float val1; \
+  .float val2; \
+  .float val3; \
+  .result; \
+  .popsection
+#endif
 
 #define TEST_FP_OP_S_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
 test_ ## testnum: \
@@ -500,18 +524,35 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, 0, float result, val1, 0.0, 0.0, \
                     fcvt.d.s f3, f0; fcvt.s.d f3, f3; fmv.x.s a0, f3)
 
+#ifdef __GNU__
 #define TEST_FCVT_H_S( testnum, result, val1 ) \
   TEST_FP_OP_H_INTERNAL( testnum, 0, float16 result, val1, 0.0, 0.0, \
                     fcvt.s.h f3, f0; fcvt.h.s f3, f3; fmv.x.h a0, f3)
+#else
+#define TEST_FCVT_H_S( testnum, result, val1 ) \
+  TEST_FP_OP_H_INTERNAL( testnum, 0, float result, val1, 0.0, 0.0, \
+                    fcvt.s.h f3, f0; fcvt.h.s f3, f3; fmv.x.h a0, f3)
+#endif
 
+#ifdef __GNU__
 #define TEST_FCVT_H_D( testnum, result, val1 ) \
   TEST_FP_OP_H_INTERNAL( testnum, 0, float16 result, val1, 0.0, 0.0, \
                     fcvt.d.h f3, f0; fcvt.h.d f3, f3; fmv.x.h a0, f3)
+#else
+#define TEST_FCVT_H_D( testnum, result, val1 ) \
+  TEST_FP_OP_H_INTERNAL( testnum, 0, float result, val1, 0.0, 0.0, \
+                    fcvt.d.h f3, f0; fcvt.h.d f3, f3; fmv.x.h a0, f3)
+#endif
 
-
+#ifdef __GNU__
 #define TEST_FP_OP1_H( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.h a0, f3;)
+#else
+#define TEST_FP_OP1_H( testnum, inst, flags, result, val1 ) \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, float result, val1, 0.0, 0.0, \
+                    inst f3, f0; fmv.x.h a0, f3;)
+#endif
 
 #define TEST_FP_OP1_S( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, 0.0, 0.0, \
@@ -547,9 +588,15 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, 0.0, \
                     inst f3, f0, f1; fmv.x.s a0, f3)
 
+#ifdef __GNU__
 #define TEST_FP_OP2_H( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, val1, val2, 0.0, \
                     inst f3, f0, f1; fmv.x.h a0, f3)
+#else
+#define TEST_FP_OP2_H( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, float result, val1, val2, 0.0, \
+                    inst f3, f0, f1; fmv.x.h a0, f3)
+#endif
 
 #define TEST_FP_OP2_D32( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, val2, 0.0, \
@@ -564,9 +611,15 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, val3, \
                     inst f3, f0, f1, f2; fmv.x.s a0, f3)
 
+#ifdef __GNU__
 #define TEST_FP_OP3_H( testnum, inst, flags, result, val1, val2, val3 ) \
   TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, val1, val2, val3, \
                     inst f3, f0, f1, f2; fmv.x.h a0, f3)
+#else
+#define TEST_FP_OP3_H( testnum, inst, flags, result, val1, val2, val3 ) \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, float result, val1, val2, val3, \
+                    inst f3, f0, f1, f2; fmv.x.h a0, f3)
+#endif
 
 #define TEST_FP_OP3_D32( testnum, inst, flags, result, val1, val2, val3 ) \
   TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, val2, val3, \
@@ -644,6 +697,7 @@ test_ ## testnum: \
   .float result; \
   .popsection
 
+#ifdef __GNU__
 #define TEST_INT_FP_OP_H( testnum, inst, result, val1 ) \
 test_ ## testnum: \
   li  TESTNUM, testnum; \
@@ -659,6 +713,23 @@ test_ ## testnum: \
   test_ ## testnum ## _data: \
   .float16 result; \
   .popsection
+#else
+#define TEST_INT_FP_OP_H( testnum, inst, result, val1 ) \
+test_ ## testnum: \
+  li  TESTNUM, testnum; \
+  la  a0, test_ ## testnum ## _data ;\
+  lh  a3, 0(a0); \
+  li  a0, val1; \
+  inst f0, a0; \
+  fsflags x0; \
+  fmv.x.h a0, f0; \
+  bne a0, a3, fail; \
+  .pushsection .data; \
+  .align 1; \
+  test_ ## testnum ## _data: \
+  .float result; \
+  .popsection
+#endif
 
 #define TEST_INT_FP_OP_D32( testnum, inst, result, val1 ) \
 test_ ## testnum: \

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -381,12 +381,21 @@ test_ ## testnum: \
 # Tests floating-point instructions
 #-----------------------------------------------------------------------
 
+#ifdef __GNU__
 #define qNaNh 0h:7e00
 #define sNaNh 0h:7c01
 #define qNaNf 0f:7fc00000
 #define sNaNf 0f:7f800001
 #define qNaN 0d:7ff8000000000000
 #define sNaN 0d:7ff0000000000001
+#else
+#define qNaNh 32256                 // 7e00
+#define sNaNh 31745                 // 7c01
+#define qNaNf 2143289344            // 7fc00000
+#define sNaNf 2139095041            // 7f800001
+#define qNaN 9221120237041090560    // 7ff8000000000000
+#define sNaN 9218868437227405313    // 7ff0000000000001
+#endif
 
 #define TEST_FP_OP_H_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
 test_ ## testnum: \

--- a/isa/rv32mi/shamt.S
+++ b/isa/rv32mi/shamt.S
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
 .align 2
-.global mtvec_handler
+.weak mtvec_handler
 mtvec_handler:
   # Trapping on test 3 is good.
   li t0, 3

--- a/isa/rv64mi/access.S
+++ b/isa/rv64mi/access.S
@@ -43,7 +43,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   li a0, 2
   beq TESTNUM, a0, 2f

--- a/isa/rv64mi/breakpoint.S
+++ b/isa/rv64mi/breakpoint.S
@@ -101,7 +101,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   # Only even-numbered tests should trap.
   andi t0, TESTNUM, 1

--- a/isa/rv64mi/illegal.S
+++ b/isa/rv64mi/illegal.S
@@ -130,7 +130,7 @@ skip_bare_s:
   TEST_PASSFAIL
 
   .align 8
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   j synchronous_exception
   j msip

--- a/isa/rv64mi/ld-misaligned.S
+++ b/isa/rv64mi/ld-misaligned.S
@@ -27,7 +27,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   MISALIGNED_LOAD_HANDLER
 

--- a/isa/rv64mi/lh-misaligned.S
+++ b/isa/rv64mi/lh-misaligned.S
@@ -21,7 +21,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   MISALIGNED_LOAD_HANDLER
 

--- a/isa/rv64mi/lw-misaligned.S
+++ b/isa/rv64mi/lw-misaligned.S
@@ -23,7 +23,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   MISALIGNED_LOAD_HANDLER
 

--- a/isa/rv64mi/ma_addr.S
+++ b/isa/rv64mi/ma_addr.S
@@ -93,7 +93,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 3
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   csrr t0, mcause
   bne t0, s1, fail

--- a/isa/rv64mi/sd-misaligned.S
+++ b/isa/rv64mi/sd-misaligned.S
@@ -27,7 +27,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   MISALIGNED_STORE_HANDLER
 

--- a/isa/rv64mi/sh-misaligned.S
+++ b/isa/rv64mi/sh-misaligned.S
@@ -21,7 +21,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   MISALIGNED_STORE_HANDLER
 

--- a/isa/rv64mi/sw-misaligned.S
+++ b/isa/rv64mi/sw-misaligned.S
@@ -23,7 +23,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   MISALIGNED_STORE_HANDLER
 

--- a/isa/rv64si/csr.S
+++ b/isa/rv64si/csr.S
@@ -139,7 +139,7 @@ finish:
   TEST_PASSFAIL
 
   .align 2
-  .global stvec_handler
+  .weak stvec_handler
 stvec_handler:
   # Trapping on tests 13-15 is good news.
   li t0, 13

--- a/isa/rv64si/dirty.S
+++ b/isa/rv64si/dirty.S
@@ -78,7 +78,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   csrr t0, mcause
   add t0, t0, -CAUSE_STORE_PAGE_FAULT

--- a/isa/rv64si/icache-alias.S
+++ b/isa/rv64si/icache-alias.S
@@ -108,7 +108,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
   csrr t0, mcause
   add t0, t0, -CAUSE_STORE_PAGE_FAULT

--- a/isa/rv64si/ma_fetch.S
+++ b/isa/rv64si/ma_fetch.S
@@ -156,7 +156,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global stvec_handler
+  .weak stvec_handler
 stvec_handler:
   # tests 2, 4, 5, 6, and 8 should trap
   li a0, 2

--- a/isa/rv64si/sbreak.S
+++ b/isa/rv64si/sbreak.S
@@ -32,7 +32,7 @@ do_break:
   TEST_PASSFAIL
 
   .align 2
-  .global stvec_handler
+  .weak stvec_handler
 stvec_handler:
   li t1, CAUSE_BREAKPOINT
   csrr t0, scause

--- a/isa/rv64si/scall.S
+++ b/isa/rv64si/scall.S
@@ -65,7 +65,7 @@ do_scall:
 # Either way, we'll get the coverage we desire: such a handler must check
 # both mcause and TESTNUM, just like the following handler.
   .align 2
-  .global stvec_handler
+  .weak stvec_handler
 stvec_handler:
   csrr t0, scause
   # Check if CLIC mode

--- a/isa/rv64ssvnapot/napot.S
+++ b/isa/rv64ssvnapot/napot.S
@@ -151,7 +151,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
-  .global mtvec_handler
+  .weak mtvec_handler
 mtvec_handler:
 die:
   RVTEST_FAIL

--- a/isa/rv64uzfh/fcvt.S
+++ b/isa/rv64uzfh/fcvt.S
@@ -21,14 +21,22 @@ RVTEST_CODE_BEGIN
   TEST_INT_FP_OP_H( 3,  fcvt.h.w,                  -2.0, -2);
 
   TEST_INT_FP_OP_H( 4, fcvt.h.wu,                   2.0,  2);
+  #ifdef __GNU__
   TEST_INT_FP_OP_H( 5, fcvt.h.wu,               0h:7c00, -2);
+  #else
+  TEST_INT_FP_OP_H( 5, fcvt.h.wu,                 31744, -2);
+  #endif
 
 #if __riscv_xlen >= 64
   TEST_INT_FP_OP_H( 6,  fcvt.h.l,                   2.0,  2);
   TEST_INT_FP_OP_H( 7,  fcvt.h.l,                  -2.0, -2);
 
   TEST_INT_FP_OP_H( 8, fcvt.h.lu,                   2.0,  2);
+  #ifdef __GNU__
   TEST_INT_FP_OP_H( 9, fcvt.h.lu,               0h:7c00, -2);
+  #else
+  TEST_INT_FP_OP_H( 9, fcvt.h.wu,                 31744, -2);
+  #endif
 #endif
   
   TEST_FCVT_H_S( 10, -1.5, -1.5)

--- a/isa/rv64uzfh/fcvt_w.S
+++ b/isa/rv64uzfh/fcvt_w.S
@@ -22,8 +22,13 @@ RVTEST_CODE_BEGIN
   TEST_FP_INT_OP_H( 5,  fcvt.w.h, 0x01,          0,     0.9, rtz);
   TEST_FP_INT_OP_H( 6,  fcvt.w.h, 0x00,          1,     1.0, rtz);
   TEST_FP_INT_OP_H( 7,  fcvt.w.h, 0x01,          1,     1.1, rtz);
+  #ifdef __GNU__
   TEST_FP_INT_OP_H( 8,  fcvt.w.h, 0x00,      -2054, 0h:e803, rtz);
   TEST_FP_INT_OP_H( 9,  fcvt.w.h, 0x00,       2054, 0h:6803, rtz);
+  #else
+  TEST_FP_INT_OP_H( 8,  fcvt.w.h, 0x00,      -2054,   59395, rtz);
+  TEST_FP_INT_OP_H( 9,  fcvt.w.h, 0x00,       2054,   26627, rtz);
+  #endif  
 
   TEST_FP_INT_OP_H(12, fcvt.wu.h, 0x10,          0,    -3.0, rtz);
   TEST_FP_INT_OP_H(13, fcvt.wu.h, 0x10,          0,    -1.0, rtz);
@@ -31,8 +36,13 @@ RVTEST_CODE_BEGIN
   TEST_FP_INT_OP_H(15, fcvt.wu.h, 0x01,          0,     0.9, rtz);
   TEST_FP_INT_OP_H(16, fcvt.wu.h, 0x00,          1,     1.0, rtz);
   TEST_FP_INT_OP_H(17, fcvt.wu.h, 0x01,          1,     1.1, rtz);
+  #ifdef __GNU__
   TEST_FP_INT_OP_H(18, fcvt.wu.h, 0x10,          0, 0h:e803, rtz);
   TEST_FP_INT_OP_H(19, fcvt.wu.h, 0x00,       2054, 0h:6803, rtz);
+  #else
+  TEST_FP_INT_OP_H(18, fcvt.wu.h, 0x10,          0,   59395, rtz);
+  TEST_FP_INT_OP_H(19, fcvt.wu.h, 0x00,       2054,   26627, rtz);
+  #endif
 
 #if __riscv_xlen >= 64
   TEST_FP_INT_OP_H(22,  fcvt.l.h, 0x01,         -1,    -1.1, rtz);
@@ -48,7 +58,11 @@ RVTEST_CODE_BEGIN
   TEST_FP_INT_OP_H(35, fcvt.lu.h, 0x01,          0,     0.9, rtz);
   TEST_FP_INT_OP_H(36, fcvt.lu.h, 0x00,          1,     1.0, rtz);
   TEST_FP_INT_OP_H(37, fcvt.lu.h, 0x01,          1,     1.1, rtz);
+  #ifdef __GNU__
   TEST_FP_INT_OP_H(38, fcvt.lu.h, 0x10,          0, 0h:e483, rtz);
+  #else
+  TEST_FP_INT_OP_H(38, fcvt.lu.h, 0x10,          0,   58499, rtz);
+  #endif
 #endif
 
   # test negative NaN, negative infinity conversion


### PR DESCRIPTION
When trying to compile riscv-tests with clang,  several incompatible compilation issues between clang and gcc are met, such as:
- https://github.com/riscv-software-src/riscv-tests/pull/225
- clang doesn't support immediates like `0f:7fc00000`
- clang doesn't support bf16 until https://github.com/llvm/llvm-project/commit/e4888a37d36780872d685c68ef8b26b2e14d6d39, but it only works for X86 yet, and will not affect current release of clang (i.e. clang-14)
- GNU as let `.weak` override `.globl`, while clang lets the last directive win https://reviews.llvm.org/D90108