### PR TITLE
zicbo test zero

### DIFF
--- a/isa/Makefile
+++ b/isa/Makefile
@@ -17,6 +17,7 @@ include $(src_dir)/rv64uzfh/Makefrag
 include $(src_dir)/rv64si/Makefrag
 include $(src_dir)/rv64ssvnapot/Makefrag
 include $(src_dir)/rv64mi/Makefrag
+include $(src_dir)/rv64mzicbo/Makefrag
 endif
 include $(src_dir)/rv32ui/Makefrag
 include $(src_dir)/rv32uc/Makefrag
@@ -49,10 +50,10 @@ vpath %.S $(src_dir)
 	$(RISCV_OBJDUMP) $< > $@
 
 %.out: %
-	$(RISCV_SIM) --isa=rv64gc_zfh_svnapot $< 2> $@
+	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot $< 2> $@
 
 %.out32: %
-	$(RISCV_SIM) --isa=rv32gc_zfh_svnapot $< 2> $@
+	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot $< 2> $@
 
 define compile_template
 
@@ -95,6 +96,7 @@ $(eval $(call compile_template,rv64ua,-march=rv64g -mabi=lp64))
 $(eval $(call compile_template,rv64uf,-march=rv64g -mabi=lp64))
 $(eval $(call compile_template,rv64ud,-march=rv64g -mabi=lp64))
 $(eval $(call compile_template,rv64uzfh,-march=rv64g_zfh -mabi=lp64))
+$(eval $(call compile_template,rv64mzicbo,-march=rv64g_zicboz -mabi=lp64))
 $(eval $(call compile_template,rv64si,-march=rv64g -mabi=lp64))
 $(eval $(call compile_template,rv64ssvnapot,-march=rv64g -mabi=lp64))
 $(eval $(call compile_template,rv64mi,-march=rv64g -mabi=lp64))

--- a/isa/rv64mzicbo/Makefrag
+++ b/isa/rv64mzicbo/Makefrag
@@ -1,0 +1,8 @@
+#=======================================================================
+# Makefrag for rv64mzicbo tests
+#-----------------------------------------------------------------------
+
+rv64mzicbo_sc_tests = \
+	zero \
+
+rv64mzicbo_p_tests = $(addprefix rv64mzicbo-p-, $(rv64mzicbo_sc_tests))

--- a/isa/rv64mzicbo/zero.S
+++ b/isa/rv64mzicbo/zero.S
@@ -1,0 +1,37 @@
+#*****************************************************************************
+#-----------------------------------------------------------------------------
+#
+# Test CBO.ZERO instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  la  x1, tdat
+  .word 0x0040A00F  ; cbo.zero(x1)
+  TEST_LD_OP( 1, ld, 0, 0,  tdat )
+  TEST_LD_OP( 2, ld, 0, 8,  tdat )
+  TEST_LD_OP( 3, ld, 0, 16, tdat )
+  TEST_LD_OP( 4, ld, 0, 24, tdat )
+  TEST_LD_OP( 5, ld, 0, 32, tdat )
+  TEST_LD_OP( 6, ld, 0, 40, tdat )
+  TEST_LD_OP( 7, ld, 0, 48, tdat )
+  TEST_LD_OP( 8, ld, 0, 56, tdat )
+
+  j pass
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:  .dword 0xdeadbeefdeadbeef
+
+RVTEST_DATA_END


### PR DESCRIPTION
### What was changed?
1. Makefile for Zicbo* extensions tests.
2. Add a very simple test for CBO.ZERO: do one of them, checking all 64 bytes with 8 `ld` instructions.  Assume a 64-byte cache line size (Zic64b).  Execute the test in Machine mode, so we don't need to program the `envcfg.CBZE` bits.

After this works and is in, we can move on to Zicbom.

### What should be reviewed
@timsifive

### How this was tested or validated
not tested