### PR TITLE
Update testlib.py; remove ANSI escape sequences

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -692,7 +692,8 @@ class Gdb:
         self.active_child.sendline(command)
         self.active_child.expect("\n", timeout=timeout)
         self.active_child.expect(r"\(gdb\)", timeout=timeout)
-        return self.active_child.before.strip().decode("utf-8", errors="ignore")
+        ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+        return ansi_escape.sub('', self.active_child.before.strip().decode("utf-8", errors="ignore")).strip()
 
     def interact(self):
         """Call this from a test at a point where you just want to interact with


### PR DESCRIPTION
The control sequences (^[[?2004h and ^[[?2004l) occur after the gdb.command, which results in Exception fault. This commit removes the control sequences and strips out the blank lines (^M).