### PR TITLE
debug: Add --debug_server arg to open gdb on OpenOCD

### DIFF
--- a/debug/targets.py
+++ b/debug/targets.py
@@ -136,6 +136,7 @@ class Target:
         self.directory = os.path.dirname(path)
         self.server_cmd = parsed.server_cmd
         self.sim_cmd = parsed.sim_cmd
+        self.debug_server = parsed.debug_server
         self.temporary_binary = None
         self.compiler_supports_v = True
         Target.isolate = parsed.isolate
@@ -166,7 +167,8 @@ class Target:
         return testlib.Openocd(server_cmd=self.server_cmd,
                 config=self.openocd_config_path,
                 timeout=self.server_timeout_sec,
-                freertos=test.freertos())
+                freertos=test.freertos(),
+                debug_openocd=self.debug_server)
 
     def do_compile(self, hart, *sources):
         binary_name = (
@@ -237,6 +239,8 @@ def add_target_options(parser):
             "simulation)", default="spike")
     parser.add_argument("--server_cmd",
             help="The command to use to start the debug server (e.g. OpenOCD)")
+    parser.add_argument("--debug_server", action="store_true",
+            help="Open gdb in a separate terminal on the debug server")
 
     xlen_group = parser.add_mutually_exclusive_group()
     xlen_group.add_argument("--32", action="store_const", const=32,

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -293,8 +293,9 @@ class Openocd:
     logname = logfile.name
 
     def __init__(self, server_cmd=None, config=None, debug=False, timeout=60,
-                 freertos=False):
+                 freertos=False, debug_openocd=False):
         self.timeout = timeout
+        self.debug_openocd = debug_openocd
 
         if server_cmd:
             cmd = shlex.split(server_cmd)
@@ -387,7 +388,7 @@ class Openocd:
                         self.gdb_ports.append(int(m.group(1)))
 
                     if "telnet server disabled" in line:
-                        return process
+                        break
 
                     if not messaged and time.time() - start > 1:
                         messaged = True
@@ -395,6 +396,12 @@ class Openocd:
                     if (time.time() - start) > self.timeout:
                         raise Exception("Timed out waiting for OpenOCD to "
                                 "listen for gdb")
+
+            if self.debug_openocd:
+                # pylint: disable=consider-using-with
+                self.debugger = subprocess.Popen(["gnome-terminal", "-e",
+                                                  f"gdb --pid={process.pid}"])
+            return process
 
         except Exception:
             print_log(Openocd.logname)


### PR DESCRIPTION
Not as useful as I'd like because we don't connect until after examine() has completed, and the test is likely to time out while debugging. But good to have, and maybe I'll expand on it one day.