### PR TITLE
debug: On failure, disassemble close instructions.

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1202,7 +1202,7 @@ class GdbTest(BaseTest):
             return
         self.gdb.interrupt()
         self.gdb.command("info breakpoints", reset_delays=None)
-        self.gdb.command("disassemble", ops=20, reset_delays=None)
+        self.gdb.command("x/20i $pc-8", ops=20, reset_delays=None)
         self.gdb.command("info registers all", ops=20, reset_delays=None)
         self.gdb.command("flush regs", reset_delays=None)
         self.gdb.command("info threads", ops=20, reset_delays=None)


### PR DESCRIPTION
`disassemble` shows the whole function which is usually too much. Instead just show the nearest instructions for some context.