### PR TITLE
Get coverage of progbuf FPR accesses.

### DIFF
--- a/debug/targets/RISC-V/spike32-2.py
+++ b/debug/targets/RISC-V/spike32-2.py
@@ -12,4 +12,5 @@ class spike32_2(targets.Target):
 
     def create(self):
         return testlib.Spike(self, isa="RV32IMAFC", progbufsize=0, dmi_rti=4,
-                support_abstract_csr=True, support_haltgroups=False)
+                support_abstract_csr=True, support_abstract_fpr=True,
+                support_haltgroups=False)

--- a/debug/targets/RISC-V/spike64.py
+++ b/debug/targets/RISC-V/spike64.py
@@ -21,4 +21,5 @@ class spike64(targets.Target):
     def create(self):
         # 32-bit FPRs only
         return testlib.Spike(self, isa="RV64IMAFC", progbufsize=0,
-                abstract_rti=30, support_abstract_csr=True)
+                abstract_rti=30, support_abstract_csr=True,
+                support_abstract_fpr=True)

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -65,6 +65,7 @@ class Spike:
     def __init__(self, target, halted=False, timeout=None, with_jtag_gdb=True,
             isa=None, progbufsize=None, dmi_rti=None, abstract_rti=None,
             support_hasel=True, support_abstract_csr=True,
+            support_abstract_fpr=False,
             support_haltgroups=True, vlen=128, elen=64, harts=None):
         """Launch spike. Return tuple of its process and the port it's running
         on."""
@@ -74,6 +75,7 @@ class Spike:
         self.dmi_rti = dmi_rti
         self.abstract_rti = abstract_rti
         self.support_abstract_csr = support_abstract_csr
+        self.support_abstract_fpr = support_abstract_fpr
         self.support_hasel = support_hasel
         self.support_haltgroups = support_haltgroups
         self.vlen = vlen
@@ -148,6 +150,9 @@ class Spike:
 
         if not self.support_abstract_csr:
             cmd.append("--dm-no-abstract-csr")
+
+        if not self.support_abstract_fpr:
+            cmd.append("--dm-no-abstract-fpr")
 
         if not self.support_hasel:
             cmd.append("--dm-no-hasel")


### PR DESCRIPTION
Using the new spike support merged in
https://github.com/riscv-software-src/riscv-isa-sim/pull/1109