### PR TITLE
Increase timeouts for multi-spike test.

### DIFF
--- a/debug/targets/RISC-V/spike-multi.py
+++ b/debug/targets/RISC-V/spike-multi.py
@@ -11,9 +11,8 @@ class multispike(targets.Target):
         spike64.spike64_hart(misa=0x8000000000341129, system=1),
         spike64.spike64_hart(misa=0x8000000000341129, system=1)]
     openocd_config_path = "spike-multi.cfg"
-    # Increased timeout because we use abstract_rti to artificially slow things
-    # down.
     timeout_sec = 30
+    server_timeout_sec = 120
     implements_custom_test = True
     support_hasel = False
     support_memory_sampling = False # Needs SBA

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -790,7 +790,9 @@ class Gdb:
                 for child in self.children:
                     child.expect(r"\(gdb\)")
 
-    def interrupt(self, ops=1):
+    def interrupt(self, ops=None):
+        if not ops:
+            ops = len(self.harts)
         self.active_child.send("\003")
         self.active_child.expect(r"\(gdb\)", timeout=self.timeout * ops)
         return self.active_child.before.strip().decode()


### PR DESCRIPTION
Between October 13 and October 19, something happened that makes the multi-spike tests 4 times slower. Rolling back spike, OpenOCD, or riscv-tests doesn't affect this. Presumably it's due to a kernel or python change in my Ubuntu system.

I don't have time to look at this right now, so just increase the timeouts. :-(

If I had to guess, there could be a bug in rbb_daisychain.py that wastes a lot of time.