### PR TITLE
fix DebugFunctionCall after https://github.com/riscv-software-src/riscv-tests/commit/90d1637f8c934b218c0e0f98c942b4d60cef97e2

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -65,7 +65,7 @@ class Spike:
     def __init__(self, target, halted=False, timeout=None, with_jtag_gdb=True,
             isa=None, progbufsize=None, dmi_rti=None, abstract_rti=None,
             support_hasel=True, support_abstract_csr=True,
-            support_abstract_fpr=False,
+            support_abstract_fpr=True,
             support_haltgroups=True, vlen=128, elen=64, harts=None):
         """Launch spike. Return tuple of its process and the port it's running
         on."""


### PR DESCRIPTION
The DebugFunctionCall fails after https://github.com/riscv-software-src/riscv-tests/commit/90d1637f8c934b218c0e0f98c942b4d60cef97e2.

Changing the default value seems to fix the issue.