### PR TITLE
Specify trigger type=2 in trigger.S

### DIFF
--- a/debug/programs/trigger.S
+++ b/debug/programs/trigger.S
@@ -40,6 +40,7 @@ write_loop:
         j       main_exit
 
 write_store_trigger:
+        /* 2<<60 is for RV64. 2<<28 is for RV32. That's safe because on RV64 bits 28 and 29 are 0. */
         li      a0, (2<<60) | (2<<28) | (1<<6) | (1<<1)
         li      a1, 0xdeadbee0
         jal     write_triggers

--- a/debug/programs/trigger.S
+++ b/debug/programs/trigger.S
@@ -40,14 +40,14 @@ write_loop:
         j       main_exit
 
 write_store_trigger:
-        li      a0, (1<<6) | (1<<1)
+        li      a0, (2<<60) | (2<<28) | (1<<6) | (1<<1)
         li      a1, 0xdeadbee0
         jal     write_triggers
         la      a0, data
         jal     read_triggers
 
 write_load_trigger:
-        li      a0, (1<<6) | (1<<0)
+        li      a0, (2<<60) | (2<<28) | (1<<6) | (1<<0)
         li      a1, 0xfeedac00
         jal     write_triggers
         la      a0, data


### PR DESCRIPTION
Previous tests implicitly assume triggers only support type=2. However, a trigger may support multiple types, i.e., type=15. This commit explicitly specifies type=2 in trigger.S to support type 15.