### PR TITLE
Fix VcsSim lognames API

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -240,6 +240,7 @@ class VcsSim:
     # pylint: disable-next=consider-using-with
     logfile = tempfile.NamedTemporaryFile(prefix='simv', suffix='.log')
     logname = logfile.name
+    lognames = [logname]
 
     def __init__(self, sim_cmd=None, debug=False, timeout=300):
         if sim_cmd:


### PR DESCRIPTION
This API was introduced by c9f43c165
"Test daisy chained homogeneous spike instances. (#334)" where multiple logs were needed.

However, this API was not implemented for `VcsSim`
so verilated rocket chip wont run, which will complain

    File riscv-tests/debug/testlib.py, line 1145, in run
      self.classSetup()
    File riscv-tests/debug/testlib.py, line 1199, in classSetup
      BaseTest.classSetup(self)
    File riscv-tests/debug/testlib.py, line 1110, in classSetup
      self.logs += self.target_process.lognames
    AttributeError: 'VcsSim' object has no attribute 'lognames'
    
This is related to https://github.com/chipsalliance/playground/pull/46