### PR TITLE
Add tests that make a hart unavailable while running

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -1856,6 +1856,29 @@ class CeaseStepiTest(ProgramTest):
         except CouldNotReadRegisters:
             pass
 
+class CeaseRunTest(ProgramTest):
+    """Test that we work correctly when the hart we're debugging ceases to
+    respond."""
+    def early_applicable(self):
+        return self.hart.support_cease
+
+    def test(self):
+        self.gdb.b("main")
+        output = self.gdb.c()
+        assertIn("Breakpoint", output)
+        assertIn("main", output)
+
+        self.gdb.p("$pc=precease")
+        self.gdb.c(wait=False)
+        self.gdb.expect(r"\S+ became unavailable.")
+        self.gdb.interrupt()
+        try:
+            self.gdb.p("$pc")
+            assert False, ("Registers shouldn't be accessible when the hart is "
+                           "unavailable.")
+        except CouldNotReadRegisters:
+            pass
+
 class FreeRtosTest(GdbTest):
     def early_applicable(self):
         return self.target.freertos_binary


### PR DESCRIPTION
Use the `cease` instruction for this. It's unfortunately non-standard, but it does exist in Rocket so it's not crazy to use it here.