### PR TITLE
debug: Disassemble memory when a failure happens.

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1217,7 +1217,7 @@ class GdbTest(BaseTest):
             return
         self.gdb.interrupt()
         self.gdb.command("info breakpoints", reset_delays=None)
-        self.gdb.command("disassemble", ops=20, reset_delays=None)
+        self.gdb.command("x/20i $pc", ops=20, reset_delays=None)
         self.gdb.command("info registers all", ops=20, reset_delays=None)
         self.gdb.command("flush regs", reset_delays=None)
         self.gdb.command("info threads", ops=20, reset_delays=None)


### PR DESCRIPTION
This gives you less noise in the log, and more chance of figuring out what code was actually executed.