### PR TITLE
debug: Park unused harts with a cease instruction.

### DIFF
--- a/debug/programs/entry.S
+++ b/debug/programs/entry.S
@@ -204,6 +204,18 @@ trap_entry:
 loop_forever:
   j loop_forever
 
+  .align 2
+precease:
+    // Loop a while so that OpenOCD might have confirmed the resume before the
+    // hart becomes unavailable.
+    li t1, 100000
+1:
+    addi t1, t1, -1
+    bnez t1, 1b
+cease:
+  .word 0x30500073  // cease
+  j loop_forever
+
   // Fill the stack with data so we can see if it was overrun.
   .section .data
   .align 4

--- a/debug/targets.py
+++ b/debug/targets.py
@@ -50,6 +50,9 @@ class Hart:
     # is fine.
     system = None
 
+    # Supports the cease instruction, which causes a hart to become unavailable.
+    support_cease = False
+
     def __init__(self, misa=None, system=None, link_script_path=None):
         if misa:
             self.misa = misa

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1226,13 +1226,19 @@ class GdbTest(BaseTest):
         del self.gdb
         BaseTest.classTeardown(self)
 
-    def parkOtherHarts(self):
+    def parkOtherHarts(self, symbol=None):
         """Park harts besides the currently selected one in loop_forever()."""
         for hart in self.target.harts:
             # Park all harts that we're not using in a safe place.
             if hart != self.hart:
                 self.gdb.select_hart(hart)
-                self.gdb.p("$pc=loop_forever")
+                if symbol is None:
+                    if hart.support_cease:
+                        self.gdb.p("$pc=cease")
+                    else:
+                        self.gdb.p("$pc=loop_forever")
+                else:
+                    self.gdb.p(f"$pc={symbol}")
 
         self.gdb.select_hart(self.hart)
 


### PR DESCRIPTION
`cease` is not a standard RISC-V extension, but is (was?) implemented in Rocket, and also exists in some SiFive cores. It's useful to test OpenOCD behavior when a hart becomes unavailable.

See also https://github.com/chipsalliance/rocket-chip/issues/1868