### PR TITLE
Update Makefile

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -37,7 +37,7 @@ bmarks = \
 
 RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
-RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns
+RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -march=rv$(XLEN)gc -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns
 RISCV_LINK ?= $(RISCV_GCC) -T $(src_dir)/common/test.ld $(incs)
 RISCV_LINK_OPTS ?= -static -nostdlib -nostartfiles -lm -lgcc -T $(src_dir)/common/test.ld
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data


### PR DESCRIPTION
Signed-off-by: Serdar Sayın <25414028+ssayin@users.noreply.github.com>

Hello, I attempted to compile your code using a compiler built with the help of the following script, where DEFAULTARCH is set to rv32imac: https://github.com/embecosm/embecosm-toolchain-releases/blob/master/stages/build-riscv32-gcc.sh#L14 . The build fails with errors stating that the zicsr extension is required. I suggest this tiny change to also ensure backwards compatibility.