### PR TITLE
debug: Create CeaseMultiTest.

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -483,6 +483,10 @@ class NoSymbol(Exception):
     def __repr__(self):
         return f"NoSymbol({self.symbol!r})"
 
+class UnknownThread(Exception):
+    def __init__(self, explanation):
+        Exception.__init__(self, explanation)
+
 Thread = collections.namedtuple('Thread', ('id', 'description', 'target_id',
     'name', 'frame'))
 
@@ -674,7 +678,8 @@ class Gdb:
         self.select_child(h['child'])
         if not h['solo']:
             output = self.command(f"thread {h['thread'].id}", ops=5)
-            assert "Unknown" not in output
+            if "Unknown" in output:
+                raise UnknownThread(output)
 
     def push_state(self):
         self.stack.append({
@@ -854,6 +859,9 @@ class Gdb:
     def stepi(self):
         output = self.command("stepi", ops=10)
         return output
+
+    def expect(self, text, ops=1):
+        return self.active_child.expect(text, timeout=ops * self.timeout)
 
     def load(self):
         output = self.system_command("load", ops=1000)


### PR DESCRIPTION
Confirm basic debug still works when other harts have been parked using a `cease` instruction. Check that the unavailable harts are inaccessible from gdb.

Add Gdb.expect()
Parse "unknown thread" error from gdb.