### PR TITLE
debug: Remove unnecessary exit() functions.

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -521,10 +521,7 @@ class DebugTest(GdbSingleHartTest):
         self.gdb.b("_exit")
 
     def exit(self, expected_result=0xc86455d4):
-        output = self.gdb.c()
-        assertIn("Breakpoint", output)
-        assertIn("_exit", output)
-        assertEqual(self.gdb.p("status"), expected_result)
+        super().exit(expected_result)
 
 class DebugCompareSections(DebugTest):
     def test(self):
@@ -943,13 +940,6 @@ class Semihosting(GdbSingleHartTest):
         self.gdb.load()
         self.parkOtherHarts()
         self.gdb.b("_exit")
-
-    def exit(self, expected_result=0):
-        output = self.gdb.c()
-        assertIn("Breakpoint", output)
-        assertIn("_exit", output)
-        assertEqual(self.gdb.p("status"), expected_result)
-        return output
 
     def test(self):
         with tempfile.NamedTemporaryFile(suffix=".data") as temp:

--- a/debug/programs/semihosting.c
+++ b/debug/programs/semihosting.c
@@ -72,4 +72,6 @@ begin:
     fd = open(filename, O_WRONLY, 0644);
     write(fd, message, strlen(message));
     write(1, message2, strlen(message2));
+
+    return 10;
 }

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1266,6 +1266,7 @@ class GdbTest(BaseTest):
         assertIn("Breakpoint", output)
         assertIn("_exit", output)
         assertEqual(self.gdb.p("status"), expected_result)
+        return output
 
 class GdbSingleHartTest(GdbTest):
     def classSetup(self):


### PR DESCRIPTION
Also make the semi-hosting test program return 10. That's more fragile than returning 0, so makes for a better test.