### PR TITLE
Fix clean in isa/ with non-default compiler

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -37,7 +37,7 @@ debug-check-fast:
 	$(MAKE) -C debug -f $(debug_src_dir)/Makefile src_dir=$(debug_src_dir) XLEN=$(XLEN) spike$(XLEN)
 
 clean:
-	[ ! -d isa ]        || $(MAKE) -C isa -f $(isa_src_dir)/Makefile src_dir=$(isa_src_dir) clean
+	[ ! -d isa ]        || $(MAKE) -C isa -f $(isa_src_dir)/Makefile src_dir=$(isa_src_dir) XLEN=$(XLEN) $(RISCV_PREFIX_VAR) clean
 	[ ! -d benchmarks ] || $(MAKE) -C benchmarks -f $(bmarkdir)/Makefile src_dir=$(bmarkdir) clean
 	[ ! -d debug ]      || $(MAKE) -C debug -f $(debug_src_dir)/Makefile src_dir=$(debug_src_dir) clean
 


### PR DESCRIPTION
Since https://github.com/riscv-software-src/riscv-tests/commit/58eb560a84ea2d6a392f7e75bba649a0c5946617, the list of active tests in isa/ depends on running the RISC-V compiler via the COMPILER_SUPPORTS_* macros, so pass the necessary options from the top-level Makefile when invoking make clean there.