### PR TITLE
Pass --misaligned flag to Spike to run ISA tests

### DIFF
--- a/isa/Makefile
+++ b/isa/Makefile
@@ -50,10 +50,10 @@ vpath %.S $(src_dir)
 	$(RISCV_OBJDUMP) $< > $@
 
 %.out: %
-	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot $< 2> $@
+	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot --misaligned $< 2> $@
 
 %.out32: %
-	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot $< 2> $@
+	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot --misaligned $< 2> $@
 
 define compile_template
 


### PR DESCRIPTION
...because the ma_data test requires this feature.

Don't merge until https://github.com/riscv-software-src/riscv-isa-sim/pull/1206 is merged.