### PR TITLE
Fix ma_fetch test for norvc

### DIFF
--- a/isa/rv64si/ma_fetch.S
+++ b/isa/rv64si/ma_fetch.S
@@ -212,7 +212,7 @@ stvec_handler:
   bne a0, t0, fail
 1:
 
-  addi a1, a1, 12
+  addi a1, a1, 8
   csrw sepc, a1
   sret
 


### PR DESCRIPTION
The trap handler for norvc systems has an incorrect jump offset, which will result `gp` store incorrect test numbers because `li gp` will get skipped by mistake.

This bug was introduced in https://github.com/riscv-software-src/riscv-tests/commit/7b4922e130bb520f9328dca77cf7330df96ce2f9 The commit modified `a1` with `addi`, but `a1` is also used in following `mepc`, thus causing a wrong jump. The original intention of modifying mepc is to skip RVC instructions.

The bug only affects systems without RVC since the trap handler is only called then.

@aswaterman PTAL