### PR TITLE
Update register name to satp

### DIFF
--- a/benchmarks/pmp/pmp.c
+++ b/benchmarks/pmp/pmp.c
@@ -43,7 +43,7 @@ static void init_pt()
 #else
   uintptr_t vm_choice = SATP_MODE_SV32;
 #endif
-  write_csr(sptbr, ((uintptr_t)l1pt >> RISCV_PGSHIFT) |
+  write_csr(satp, ((uintptr_t)l1pt >> RISCV_PGSHIFT) |
                    (vm_choice * (SATP_MODE & ~(SATP_MODE<<1))));
   write_csr(pmpaddr2, -1);
   write_csr(pmpcfg0, (PMP_NAPOT | PMP_R) << 16);


### PR DESCRIPTION
Related to issue https://github.com/riscv-software-src/riscv-tests/issues/453
It seems to be the only modification needed there. It may break backward compatibility with (very?) old compilers.

Signed-off-by: Pascal Cotret <pascal.cotret@gmail.com>