### PR TITLE
Fix intermittent IcountTest failure on multi hart.

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -1975,7 +1975,7 @@ class EtriggerTest(DebugTest):
         assertIn("trap_entry", self.gdb.where())
 
 class IcountTest(DebugTest):
-    compile_args = ("programs/infinite_loop.S", "-DMULTICORE")
+    compile_args = ("programs/infinite_loop.S", )
 
     def setup(self):
         DebugTest.setup(self)


### PR DESCRIPTION
Don't build with -DMULTICORE because this is not a test that really does multicore. It's one where we just want to park the other harts.