### PR TITLE
Fix breakpoint.S failing when tcontrol is implemented

### DIFF
--- a/isa/rv64mi/breakpoint.S
+++ b/isa/rv64mi/breakpoint.S
@@ -16,6 +16,16 @@ RVTEST_CODE_BEGIN
   # Set up breakpoint to trap on M-mode fetches.
   li TESTNUM, 2
 
+  # Set tcontrol.mte, otherwise breakpoints are disabled. This may trap,
+  # because tcontrol is an optional register.
+  la a0, 1f
+  csrrw a0, mtvec, a0
+  li a1, 0x8
+  csrs tcontrol, a1
+.p2align 2
+1:
+  csrw mtvec, a0
+
   # Skip tselect if hard-wired.
   csrw tselect, x0
   csrr a1, tselect


### PR DESCRIPTION
`tcontrol.mte` is required to reset to 0 when implemented. When 0, triggers don't fire. This patch attempts to set `tcontrol.mte` before beginning the breakpoint test, skipping over the `tcontrol` access if it traps.

There weren't any encoding.h constants for tcontrol, so I raised https://github.com/riscv/riscv-test-env/pull/42 to add those. If that gets merged, I'll update this PR to use the correct symbolic constants.