### PR TITLE
Include Zicntr in Spike ISA string

### DIFF
--- a/isa/Makefile
+++ b/isa/Makefile
@@ -50,10 +50,10 @@ vpath %.S $(src_dir)
 	$(RISCV_OBJDUMP) $< > $@
 
 %.out: %
-	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot --misaligned $< 2> $@
+	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot_zicntr --misaligned $< 2> $@
 
 %.out32: %
-	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot --misaligned $< 2> $@
+	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot_zicntr --misaligned $< 2> $@
 
 define compile_template
 


### PR DESCRIPTION
Spike no longer enables Zicntr by default, so turn it on explicitly.

cc @jerryz123