### PR TITLE
Update OpenOCD cfg files to new syntax

### DIFF
--- a/debug/targets/RISC-V/spike-1.cfg
+++ b/debug/targets/RISC-V/spike-1.cfg
@@ -1,8 +1,8 @@
-adapter_khz     10000
+adapter speed     10000
 
-interface remote_bitbang
-remote_bitbang_host $::env(REMOTE_BITBANG_HOST)
-remote_bitbang_port $::env(REMOTE_BITBANG_PORT)
+adapter driver remote_bitbang
+remote_bitbang host $::env(REMOTE_BITBANG_HOST)
+remote_bitbang port $::env(REMOTE_BITBANG_PORT)
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
@@ -26,7 +26,7 @@ riscv expose_custom 1,12345-12348
 init
 
 set challenge [riscv authdata_read]
-riscv authdata_write [expr $challenge + 1]
+riscv authdata_write [expr {$challenge + 1}]
 
 halt
 

--- a/debug/targets/RISC-V/spike-2-hwthread.cfg
+++ b/debug/targets/RISC-V/spike-2-hwthread.cfg
@@ -1,9 +1,9 @@
 # Connect to a mult-icore RISC-V target, exposing each hart as a thread.
-adapter_khz     10000
+adapter speed     10000
 
-interface remote_bitbang
-remote_bitbang_host $::env(REMOTE_BITBANG_HOST)
-remote_bitbang_port $::env(REMOTE_BITBANG_PORT)
+adapter driver remote_bitbang
+remote_bitbang host $::env(REMOTE_BITBANG_HOST)
+remote_bitbang port $::env(REMOTE_BITBANG_PORT)
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
@@ -30,7 +30,7 @@ riscv resume_order reversed
 init
 
 set challenge [riscv authdata_read]
-riscv authdata_write [expr $challenge + 1]
+riscv authdata_write [expr {$challenge + 1}]
 
 halt
 

--- a/debug/targets/RISC-V/spike-2.cfg
+++ b/debug/targets/RISC-V/spike-2.cfg
@@ -1,9 +1,9 @@
 # Connect to a mult-icore RISC-V target, exposing each hart as a thread.
-adapter_khz     10000
+adapter speed     10000
 
-interface remote_bitbang
-remote_bitbang_host $::env(REMOTE_BITBANG_HOST)
-remote_bitbang_port $::env(REMOTE_BITBANG_PORT)
+adapter driver remote_bitbang
+remote_bitbang host $::env(REMOTE_BITBANG_HOST)
+remote_bitbang port $::env(REMOTE_BITBANG_PORT)
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
@@ -27,7 +27,7 @@ foreach t [target names] {
 init
 
 set challenge [riscv authdata_read]
-riscv authdata_write [expr $challenge + 1]
+riscv authdata_write [expr {$challenge + 1}]
 
 foreach t [target names] {
     targets $t

--- a/debug/targets/RISC-V/spike-multi.cfg
+++ b/debug/targets/RISC-V/spike-multi.cfg
@@ -1,9 +1,9 @@
 # Connect to a mult-icore RISC-V target, exposing each hart as a thread.
-adapter_khz     10000
+adapter speed     10000
 
-interface remote_bitbang
-remote_bitbang_host $::env(REMOTE_BITBANG_HOST)
-remote_bitbang_port $::env(REMOTE_BITBANG_PORT)
+adapter driver remote_bitbang
+remote_bitbang host $::env(REMOTE_BITBANG_HOST)
+remote_bitbang port $::env(REMOTE_BITBANG_PORT)
 
 jtag newtap riscv.0 cpu -irlen 5 -expected-id 0x10e31913
 jtag newtap riscv.1 cpu -irlen 5 -expected-id 0x10e31913
@@ -33,11 +33,11 @@ init
 
 targets riscv.0.cpu0
 set challenge [riscv authdata_read]
-riscv authdata_write [expr $challenge + 1]
+riscv authdata_write [expr {$challenge + 1}]
 
 targets riscv.1.cpu0
 set challenge [riscv authdata_read]
-riscv authdata_write [expr $challenge + 1]
+riscv authdata_write [expr {$challenge + 1}]
 
 foreach t [target names] {
     targets $t

--- a/debug/targets/SiFive/Freedom/Freedom.cfg
+++ b/debug/targets/SiFive/Freedom/Freedom.cfg
@@ -1,4 +1,4 @@
-adapter_khz     10000
+adapter speed     10000
 
 source [find interface/ftdi/olimex-arm-usb-tiny-h.cfg]
 

--- a/debug/targets/SiFive/HiFive1.cfg
+++ b/debug/targets/SiFive/HiFive1.cfg
@@ -1,11 +1,11 @@
-adapter_khz     10000
+adapter speed     10000
 
-interface ftdi
-ftdi_device_desc "Dual RS232-HS"
-ftdi_vid_pid 0x0403 0x6010
+adapter driver ftdi
+ftdi device_desc "Dual RS232-HS"
+ftdi vid_pid 0x0403 0x6010
 
-ftdi_layout_init 0x0008 0x001b
-ftdi_layout_signal nSRST -oe 0x0020
+ftdi layout_init 0x0008 0x001b
+ftdi layout_signal nSRST -oe 0x0020
 
 # ...
 

--- a/debug/targets/SiFive/HiFiveUnleashed.cfg
+++ b/debug/targets/SiFive/HiFiveUnleashed.cfg
@@ -1,11 +1,11 @@
-adapter_khz     10000
+adapter speed     10000
 
-interface ftdi
-ftdi_device_desc "Dual RS232-HS"
-ftdi_vid_pid 0x0403 0x6010
+adapter driver ftdi
+ftdi device_desc "Dual RS232-HS"
+ftdi vid_pid 0x0403 0x6010
 
-ftdi_layout_init 0x0008 0x001b
-ftdi_layout_signal nSRST -oe 0x0020
+ftdi layout_init 0x0008 0x001b
+ftdi layout_signal nSRST -oe 0x0020
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x20000913


### PR DESCRIPTION
We were using a variety of deprecated commands.

The driving force behind this was the new way to use `expr{}` as the old way no longer works with mainline OpenOCD.