### PR TITLE
Add a way to exclude tests by specifying an exclusion file

### DIFF
--- a/debug/Makefile
+++ b/debug/Makefile
@@ -23,7 +23,8 @@ run.%:
 		--isolate \
 		--print-failures \
 		--sim_cmd $(RISCV)/bin/$(RISCV_SIM) \
-		--server_cmd $(RISCV)/bin/openocd
+		--server_cmd $(RISCV)/bin/openocd \
+		$(if $(EXCLUDE_TESTS),--exclude-tests $(EXCLUDE_TESTS))
 
 # Target to check all the multicore options.
 multi-tests: spike32-2 spike32-2-hwthread

--- a/debug/excluded.yaml.example
+++ b/debug/excluded.yaml.example
@@ -1,0 +1,17 @@
+# This is an example file showing the exclusion list format.
+# It can be passed to gdb_server.py using the --exclude-tests argument.
+
+
+# Tests excluded for all targets
+all:
+  - SimpleF18Test
+
+# Tests excluded for the "spike32" target only
+spike32:
+  - MemTest32
+  - PrivRw
+  - Sv32Test
+
+# Tests excluded for the "spike64" target only
+spike64:
+  - UserInterrupt

--- a/debug/requirements.txt
+++ b/debug/requirements.txt
@@ -1,1 +1,2 @@
 pexpect>=4.0.0
+pyyaml>=3.12


### PR DESCRIPTION
This patch adds a way to specify a yaml file which specifies either for each target individually or for all targets to exclude tests. Example file format is included in excluded.yaml.example.