### PR TITLE
Fix for test program compilation failures due to lack of `zicsr` extension in `-march=rvXX...`

### DIFF
--- a/debug/targets.py
+++ b/debug/targets.py
@@ -196,7 +196,7 @@ class Target:
                 "-o", binary_name]
 
         if hart.extensionSupported('e'):
-            args.append("-march=rv32e")
+            args.append("-march=rv32e_zicsr")
             args.append("-mabi=ilp32e")
             args.append("-DRV32E")
         else:
@@ -206,7 +206,7 @@ class Target:
                     march += letter
             if hart.extensionSupported("v") and self.compiler_supports_v:
                 march += "v"
-            args.append(f"-march={march}")
+            args.append(f"-march={march}_zicsr")
             if hart.xlen == 32:
                 args.append("-mabi=ilp32")
             else:


### PR DESCRIPTION
Fix for:

* https://github.com/riscv-software-src/riscv-tests/issues/482

Note that this fix means that the tests will probably fail to compile with a pre GCC 12 RISC-V toolchain which predates the separation of the `zicsr` (and `zifencei`) extension(s) out from the base integer ISA. But I didn't think that it was worthwhile complicating the script further by trying to cater for older toolchains in the script.