### PR TITLE
debug: Don't rely on RISCV env

### DIFF
--- a/debug/Makefile
+++ b/debug/Makefile
@@ -1,4 +1,3 @@
-RISCV_SIM ?= spike
 XLEN ?= 64
 
 src_dir ?= .
@@ -22,8 +21,6 @@ run.%:
 		$(word 3, $(subst ., ,$@)) \
 		--isolate \
 		--print-failures \
-		--sim_cmd $(RISCV)/bin/$(RISCV_SIM) \
-		--server_cmd $(RISCV)/bin/openocd \
 		$(if $(EXCLUDE_TESTS),--exclude-tests $(EXCLUDE_TESTS))
 
 # Target to check all the multicore options.

--- a/debug/README.md
+++ b/debug/README.md
@@ -9,11 +9,10 @@ confident that the actual debug interface is functioning correctly.
 Requirements
 ============
 The following should be in the user's path:
-* riscv64-unknown-elf-gcc (`rvv-0.9.x` branch for riscv-gnu-toolchain should
-  work if master does not have vector support yet)
-* riscv64-unknown-elf-gdb (can be overridden with `--gdb` when running
-  gdbserver.py manually), which should be the latest from
-  git://sourceware.org/git/binutils-gdb.git.
+* riscv64-unknown-elf-gcc (GCC 12 and later should work). If your binary has a
+  different name, you can set the RISCV_TESTS_DEBUG_GCC environment variable.
+* riscv64-unknown-elf-gdb. If your binary has a
+  different name, you can set the RISCV_TESTS_DEBUG_GDB environment variable.
 * spike (can be overridden with `--sim_cmd` when running gdbserver.py
   manually), which should be the latest from
   https://github.com/riscv/riscv-isa-sim.git.


### PR DESCRIPTION
That made sense when mostly people used riscv-tools, but now they get tools from all sorts of places and most of them are suitable for the debug tests.

Also document RISCV_TESTS_DEBUG_GCC and RISCV_TESTS_DEBUG_GDB environment variables in the README.

The github workflows that rely on these tests don't use the Makefile, but instead invoke gdbserver.py directly, so they're not affected by this change.

Fixes #481