### PR TITLE
enable interrupts if tcontrol.mte is not implemented

### DIFF
--- a/isa/rv64mi/breakpoint.S
+++ b/isa/rv64mi/breakpoint.S
@@ -22,10 +22,16 @@ RVTEST_CODE_BEGIN
   csrrw a0, mtvec, a0
   li a1, 0x8
   csrs tcontrol, a1
+  csrw mtvec, a0
+  j tcontrol_present
 .p2align 2
 1:
   csrw mtvec, a0
+  # triggers with action = 0 are suppressed when
+  # mie is 0 and tcontrol0 is not implemented
+  csrsi mstatus, MSTATUS_MIE
 
+tcontrol_present:
   # Skip tselect if hard-wired.
   csrw tselect, x0
   csrr a1, tselect


### PR DESCRIPTION
When `tcontrol` is not implemented, the hardware prevents triggers with `action=0` from matching while in M-mode and while `MIE` in `mstatus` is 0. 