### PR TITLE
debug: Re-enable unavailable tests, and fix them for github

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -1816,10 +1816,9 @@ class UnavailableMultiTest(GdbTest):
             "-DDEFINE_FREE")
 
     def early_applicable(self):
-        return False    # This test fails in github workflows
-        #return (self.hart.support_cease or
-        #        self.target.support_unavailable_control) \
-        #    and len(self.target.harts) > 1
+        return (self.hart.support_cease or
+                self.target.support_unavailable_control) \
+            and len(self.target.harts) > 1
 
     def setup(self):
         ProgramTest.setup(self)
@@ -1886,9 +1885,8 @@ class UnavailableRunTest(ProgramTest):
     """Test that we work correctly when the hart we're debugging ceases to
     respond."""
     def early_applicable(self):
-        return False    # This test fails in github workflows
-        #return self.hart.support_cease or \
-        #    self.target.support_unavailable_control
+        return self.hart.support_cease or \
+            self.target.support_unavailable_control
 
     def test(self):
         self.gdb.b("main")
@@ -1924,8 +1922,7 @@ class UnavailableCycleTest(ProgramTest):
     """Test that harts can be debugged after becoming temporarily
     unavailable."""
     def early_applicable(self):
-        return False    # This test fails in github workflows
-        #return self.target.support_unavailable_control
+        return self.target.support_unavailable_control
 
     def test(self):
         self.gdb.b("main")

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -432,7 +432,7 @@ class Openocd:
         self.command_count += 1
         self.process.stdin.write(magic + b"\n")
         self.process.stdin.flush()
-        m = self.expect(rb"(.*)^> " + re.escape(magic))
+        m = self.expect(rb"(.*)^>\s*" + re.escape(magic))
         return m.group(1)
 
     def expect(self, regex, message=None):


### PR DESCRIPTION
Tolerate more whitespace from OpenOCD CLI. During the github workflow this character is \n, while on my computer it's ' '. I'm sure there's a good reason for that, but it doesn't seem worth figuring out what that reason is.

Confirmed through https://github.com/riscv/riscv-openocd/pull/890 that this does in fact work.
