### PR TITLE
debug: Actually run tests in github workflow.

### DIFF
--- a/.github/workflows/spike-openocd-tests.yml
+++ b/.github/workflows/spike-openocd-tests.yml
@@ -1,0 +1,172 @@
+# Build Spike and run a couple of debug tests.
+
+name: Test OpenOCD against 2 spike configurations
+
+env:
+  SPIKE_REPO: https://github.com/riscv-software-src/riscv-isa-sim.git
+  SPIKE_REV: master
+  RISCV_TESTS_REPO: https://github.com/riscv-software-src/riscv-tests.git
+  RISCV_TESTS_REV: master
+  OPENOCD_REPO: https://github.com/riscv/riscv-openocd.git
+  OPENOCD_REV: riscv
+  TOOLCHAIN_URL: https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-1/xpack-riscv-none-elf-gcc-12.2.0-1-linux-x64.tar.gz
+
+on:
+  # Run on merges to master to populate the cache with entities that are
+  # accessible by every pull request.
+  push:
+    branches:
+      - riscv
+    paths:
+    - 'debug/**'
+    - '.github/workflows/spike-openocd-tests.yml'
+  pull_request:
+    types: [synchronize, opened, reopened]
+    paths:
+    - 'debug/**'
+    - '.github/workflows/spike-openocd-tests.yml'
+
+# There is some commented out code below that would be useful in adding this
+# workflow to other repos. Ideally we can come up with something that would
+# leave this file almost identical between repos, so they can all easily run
+# this test suite.
+
+jobs:
+  test:
+    name: Test debug (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y device-tree-compiler build-essential
+
+      - name: Get revisions of dependencies
+        run: |
+          SPIKE_COMMIT=$( git ls-remote "$SPIKE_REPO" $SPIKE_REV | awk '{ print $1; }' )
+          OPENOCD_COMMIT=$( git ls-remote "$OPENOCD_REPO" $OPENOCD_REV | awk '{ print $1; }' )
+          echo "Revison of Spike: $SPIKE_COMMIT"
+          echo "Revision of OpenOCD: $OPENOCD_COMMIT"
+          # Save for later use
+          echo "SPIKE_COMMIT=$SPIKE_COMMIT" >> $GITHUB_ENV
+          echo "OPENOCD_COMMIT=$OPENOCD_COMMIT" >> $GITHUB_ENV
+
+      - name: Get the toolchain from cache (if available)
+        id: cache-restore-toolchain
+        uses: actions/cache/restore@v3
+        with:
+          path: /opt/riscv/toolchain
+          key: "toolchain-${{env.TOOLCHAIN_URL}}"
+
+      - if: ${{ steps.cache-restore-toolchain.outputs.cache-hit != 'true' }}
+        name: Download Toolchain (if not cached)
+        run: |
+          mkdir -p /opt/riscv/toolchain
+          wget --progress=dot:giga $TOOLCHAIN_URL -O /tmp/toolchain.tar.gz
+
+      - if: ${{ steps.cache-restore-toolchain.outputs.cache-hit != 'true' }}
+        name: Install Toolchain (if not cached)
+        run: tar zxf /tmp/toolchain.tar.gz --strip-components=1 -C /opt/riscv/toolchain
+
+      - name: Save the toolchain to the cache (if necessary)
+        id: cache-save-toolchain
+        uses: actions/cache/save@v3
+        with:
+          path: /opt/riscv/toolchain
+          key: "toolchain-${{env.TOOLCHAIN_URL}}"
+
+      - name: Get OpenOCD from cache (if available)
+        id: cache-restore-openocd
+        uses: actions/cache/restore@v3
+        with:
+          path: /opt/riscv/openocd
+          key: "openocd-${{env.OPENOCD_COMMIT}}"
+
+      - if: ${{ steps.cache-restore-openocd.outputs.cache-hit != 'true' }}
+        name: Download OpenOCD source (if not cached)
+        run: |
+          git clone "$OPENOCD_REPO"
+          cd riscv-openocd
+          git checkout "$OPENOCD_COMMIT"
+          git submodule update --init --recursive
+
+      - if: ${{ steps.cache-restore-openocd.outputs.cache-hit != 'true' }}
+        name: Build OpenOCD (if not cached)
+        run: |
+          cd riscv-openocd
+          ./bootstrap
+          ./configure --prefix=/opt/riscv/openocd
+          make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)"
+          make install
+
+      - if: ${{ steps.cache-restore-openocd.outputs.cache-hit != 'true' }}
+        name: Save OpenOCD to cache (if built)
+        id: cache-save-openocd
+        uses: actions/cache/save@v3
+        with:
+          path: /opt/riscv/openocd
+          key: "openocd-${{env.OPENOCD_COMMIT}}"
+
+      - name: Get spike from cache (if available)
+        id: cache-restore-spike
+        uses: actions/cache/restore@v3
+        with:
+          path: /opt/riscv/spike
+          key: "spike-${{env.SPIKE_COMMIT}}"
+
+      - if: ${{ steps.cache-restore-spike.outputs.cache-hit != 'true' }}
+        name: Download Spike source (if not cached)
+        run: |
+          git clone "$SPIKE_REPO"
+          cd riscv-isa-sim
+          git checkout "$SPIKE_COMMIT"
+          git submodule update --init --recursive
+
+      - if: ${{ steps.cache-restore-spike.outputs.cache-hit != 'true' }}
+        name: Build Spike (if not cached)
+        run: |
+          cd riscv-isa-sim
+          mkdir build && cd build
+          ../configure --prefix=/opt/riscv/spike
+          make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)"
+          make install
+
+      - if: ${{ steps.cache-restore-spike.outputs.cache-hit != 'true' }}
+        name: Save spike to cache (if built)
+        id: cache-save-spike
+        uses: actions/cache/save@v3
+        with:
+          path: /opt/riscv/spike
+          key: "spike-${{env.SPIKE_COMMIT}}"
+
+      - name: Run Spike32 Tests
+        id: spike32-tests
+        run: |
+          cd debug
+          ./gdbserver.py targets/RISC-V/spike32.py --print-failures \
+              --gcc /opt/riscv/toolchain/bin/riscv-none-elf-gcc \
+              --gdb /opt/riscv/toolchain/bin/riscv-none-elf-gdb \
+              --sim_cmd /opt/riscv/spike/bin/spike \
+              --server_cmd /opt/riscv/openocd/bin/openocd
+
+      - name: Run Spike64-2 Tests
+        if: success() || steps.spike32-tests.conclusion == 'failure'
+        run: |
+          cd debug
+          ./gdbserver.py targets/RISC-V/spike64-2.py --print-failures \
+              --gcc /opt/riscv/toolchain/bin/riscv-none-elf-gcc \
+              --gdb /opt/riscv/toolchain/bin/riscv-none-elf-gdb \
+              --sim_cmd /opt/riscv/spike/bin/spike \
+              --server_cmd /opt/riscv/openocd/bin/openocd
+
+      - name: Archive test logs
+        # Proceed even if there was a failed test
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs
+          path: riscv-tests/debug/logs


### PR DESCRIPTION
This should avoid problems like we just had where bad tests can break the OpenOCD workflow. These tests only run if any debug files are changed, so should have no impact at all on non-debug tests in this repo.