### PR TITLE
Disable timer interrupt to fix some bugs

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -1039,8 +1039,10 @@ class InterruptTest(GdbSingleHartTest):
             local = self.gdb.p("local")
             if interrupt_count > 1000 and \
                     local > 1000:
+                self.disable_timer()
                 return
 
+        self.disable_timer()
         assertGreater(interrupt_count, 1000)
         assertGreater(local, 1000)
 
@@ -1191,6 +1193,8 @@ class MulticoreRunAllHaltOne(GdbTest):
         time.sleep(1)
         self.gdb.p("buf", fmt="")
 
+        self.disable_timer(interrupt=True)
+
 class MulticoreRtosSwitchActiveHartTest(GdbTest):
     compile_args = ("programs/multicore.c", "-DMULTICORE")
 
@@ -1219,6 +1223,8 @@ class MulticoreRtosSwitchActiveHartTest(GdbTest):
             assertIn("hit Breakpoint", output)
             assertIn("set_trap_handler", output)
             assertNotIn("received signal SIGTRAP", output)
+
+        self.disable_timer()
 
 class SmpSimultaneousRunHalt(GdbTest):
     compile_args = ("programs/run_halt_timing.S", "-DMULTICORE")

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1411,6 +1411,13 @@ class GdbTest(BaseTest):
             # PMP registers are optional
             pass
 
+    def disable_timer(self, interrupt=False):
+        for hart in self.target.harts:
+            self.gdb.select_hart(hart)
+            if interrupt:
+                self.gdb.interrupt()
+            self.gdb.p("$mie=$mie & ~0x80")
+
     def exit(self, expected_result=10):
         self.gdb.command("delete")
         self.gdb.b("_exit")


### PR DESCRIPTION
Turn off the timer interrupt after the test case (such as InterruptTest) ends to avoid interference with other test cases.