### PR TITLE
Support limits_icount_to_one in IcountTest

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -2129,9 +2129,13 @@ class IcountTest(DebugTest):
     def test(self):
         # Execute 2 instructions.
         output = self.gdb.command("monitor riscv icount set m 2")
-        assertNotIn("Failed", output)
+        if self.target.icount_limit > 1:
+            assertNotIn("Failed", output)
+        else:
+            assertIn("Failed", output)
+            self.gdb.b("main_post_csrr")
         output = self.gdb.c()
-        assertIn("breakpoint", output)
+        assertIn("main_post_csrr", output)
         main_post_csrr = self.gdb.p("&main_post_csrr")
         assertEqual(self.gdb.p("$pc"), main_post_csrr)
 

--- a/debug/targets.py
+++ b/debug/targets.py
@@ -138,6 +138,9 @@ class Target:
     # Supports controlling hart availability through DMCUSTOM.
     support_unavailable_control = False
 
+    # Instruction count limit
+    icount_limit = 4
+
     # Internal variables:
     directory = None
     temporary_files = []


### PR DESCRIPTION
https://github.com/riscv-software-src/riscv-tests/issues/516 This is taking into account that the hardware limits count to 1.