### PR TITLE
Restore $stap and $mstatus after test translate

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -1679,6 +1679,10 @@ class TranslateTest(GdbSingleHartTest):
         assertEqual(0xdeadbeef, self.gdb.p("virtual[0]"))
         assertEqual(0x55667788, self.gdb.p("virtual[1]"))
 
+        # disable mmu
+        self.gdb.p("$mstatus=$mstatus & ~0x20000")
+        self.gdb.p("$satp=0")
+
 SATP_MODE_OFF = 0
 SATP_MODE_SV32 = 1
 SATP_MODE_SV39 = 8


### PR DESCRIPTION
In TranslateTest, $stap and $mstatus were set to enable address translation
https://github.com/riscv-software-src/riscv-tests/blob/bd0a19c136927eaa3b7296a591a896c141affb6b/debug/programs/translate.c#L167-L178

But, $stap and $mstatus were not restored after testing, resulting in invalid PTE in other test cases.

```
Debug: 22797 3032 riscv-013.c:1708 register_read_direct(): [riscv.cpu1] mstatus = 0xa00020000
Debug: 22798 3032 riscv.c:5380 riscv_get_register(): [riscv.cpu1] Read mstatus: 0xa00020000
Debug: 22799 3032 riscv.c:2230 riscv_effective_privilege_mode(): [riscv.cpu1] Effective mode=0; v=0
Debug: 22800 3032 riscv.c:5372 riscv_get_register(): [riscv.cpu1] Reading satp from target
Debug: 22801 3032 riscv-013.c:4839 riscv013_get_register(): [riscv.cpu1] reading register satp
Debug: 22802 3032 riscv-013.c:1689 register_read_direct(): [riscv.cpu1] Reading satp
Debug: 22803 3032 riscv-013.c:874 execute_abstract_command(): [riscv.cpu1] access register=0x320180 {regno=0x180 write=arg0 transfer=enabled postexec=disabled aarpostincrement=disabled aarsize=64bit}
Debug: 22813 3032 riscv-013.c:397 dump_field(): 45b w 00320180 @17 -> + 00020000 @04; 3i
Debug: 22814 3032 riscv-013.c:405 dump_field(): write: command=0x320180 {control=0x320180}
Debug: 22824 3033 riscv-013.c:397 dump_field(): 45b r 00000000 @16 -> + 00320180 @17; 3i
Debug: 22834 3033 riscv-013.c:397 dump_field(): 45b - 00000000 @16 -> + 02000002 @16; 3i
Debug: 22835 3033 riscv-013.c:411 dump_field(): read: abstractcs=0x2000002 {datacount=2 progbufsize=2}
Debug: 22845 3033 riscv-013.c:397 dump_field(): 45b r 00000000 @05 -> + 02000002 @16; 3i
Debug: 22855 3034 riscv-013.c:397 dump_field(): 45b - 00000000 @05 -> + 80000000 @05; 3i
Debug: 22856 3034 riscv-013.c:411 dump_field(): read:
Debug: 22866 3034 riscv-013.c:397 dump_field(): 45b r 00000000 @04 -> + 80000000 @05; 3i
Debug: 22876 3034 riscv-013.c:397 dump_field(): 45b - 00000000 @04 -> + 000c0801 @04; 3i
Debug: 22877 3034 riscv-013.c:411 dump_field(): read:
Debug: 22878 3034 riscv-013.c:1708 register_read_direct(): [riscv.cpu1] satp = 0x80000000000c0801
Debug: 22879 3034 riscv.c:5380 riscv_get_register(): [riscv.cpu1] Read satp: 0x80000000000c0801
Debug: 22880 3034 riscv.c:2319 riscv_mmu(): [riscv.cpu1] MMU is enabled.
Debug: 22881 3034 riscv.c:5367 riscv_get_register(): [riscv.cpu1] Read dcsr: 0x4000b043 (cached)
Debug: 22882 3035 riscv.c:5367 riscv_get_register(): [riscv.cpu1] Read satp: 0x80000000000c0801 (cached)
Debug: 22883 3035 riscv.c:2337 riscv_address_translate(): [riscv.cpu1] mode=Sv39; ppn=0xc0801; virtual=0xc0800940
Debug: 22884 3035 riscv-013.c:4167 read_memory_progbuf(): [riscv.cpu1] reading 2 elements of 4 bytes from 0xc0801018
...
...
...
Debug: 23302 3048 riscv-013.c:2997 log_memory_access64(): M[0xc080101c] reads 0x00000000
Debug: 23303 3048 riscv-013.c:3386 log_mem_access_result(): [riscv.cpu1] Succeeded to read memory via program buffer.
Debug: 23304 3048 riscv.c:2377 riscv_address_translate(): [riscv.cpu1] i=2; PTE @0xc0801018 = 0x0
Error: 23305 3048 riscv.c:2381 riscv_address_translate(): [riscv.cpu1] invalid PTE @0xc0801018: 0x0; mode=Sv39; i=2
Error: 23306 3048 riscv.c:2604 riscv_read_memory(): [riscv.cpu1] Address translation failed.
```
So,  $stap and $mstatus were  restored after test translate to solvd this bug.