### PR TITLE
 improvements to debug tests infrastructure to help with triaging process

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -11,6 +11,7 @@ import os
 import re
 import itertools
 
+from datetime import datetime
 import targets
 import testlib
 from testlib import assertEqual, assertNotEqual
@@ -2193,6 +2194,14 @@ def main():
     testlib.print_log_names = parsed.print_log_names
 
     module = sys.modules[__name__]
+
+    # initialize PRNG
+    selected_seed = parsed.seed
+    if parsed.seed is None:
+        selected_seed = int(datetime.now().timestamp())
+        print(f"PRNG seed for {target.name} is generated automatically")
+    print(f"PRNG seed for {target.name} is {selected_seed}")
+    random.seed(selected_seed)
 
     return testlib.run_all_tests(module, target, parsed)
 

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -744,7 +744,6 @@ class Gdb:
             # Force consistency.
             self.command("set print entry-values no", reset_delays=None)
             self.command(f"set remotetimeout {self.timeout}", reset_delays=None)
-            self.command(f"set remotetimeout {self.target.timeout_sec}")
             if logremote:
                 # pylint: disable-next=consider-using-with
                 remotelog = tempfile.NamedTemporaryFile(

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1232,6 +1232,9 @@ def add_test_run_options(parser):
             help="Specify yaml file listing tests to exclude")
     parser.add_argument("--target-timeout",
             help="Override the base target timeout.", default=None, type=int)
+    parser.add_argument("--seed",
+            help="Use user-specified seed value for PRNG.", default=None,
+            type=int)
     parser.add_argument("--hart",
             help="Run tests against this hart in multihart tests.",
             default=None, type=int)


### PR DESCRIPTION
This improvement fixes several issues:

1. print selected seed. Previously the seed was not printed and this
created problems with reproduction of the issues. It's still not an
ideal - meaning interactions between spike/gdb/openocd are inherently
non-determistic (since time is involved), but at least we should get
the same sources for the same seed now.

2. introduced a new option to log communications over GDB remote serial
protocol which is helpful for debugging some tests.

3. fixes setting of remotetimeout. It was silently overwritten by
default values from platform definition even if user specified one.