### PR TITLE
Clear breakpoints so that gdb will not single step

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -2139,6 +2139,7 @@ class IcountTest(DebugTest):
         main_post_csrr = self.gdb.p("&main_post_csrr")
         assertEqual(self.gdb.p("$pc"), main_post_csrr)
 
+        self.gdb.command("delete")
         self.gdb.command("monitor riscv icount clear")
 
         # Execute 1 instruction.


### PR DESCRIPTION
https://github.com/riscv-software-src/riscv-tests/blob/67e775962321ef48f77e7ab5aa4f40ce3cf82b08/debug/gdbserver.py#L2134-L2141
If there's a breakpoint set, gdb will send vCont;s:0;c:0, so cpu will execute 2 instructions when count is set to 1, with breakpoints cleared, gdb will send vCont;c.