### PR TITLE
Set PMP to create invalid address

### DIFF
--- a/debug/targets.py
+++ b/debug/targets.py
@@ -141,6 +141,9 @@ class Target:
     # Instruction count limit
     icount_limit = 4
 
+    # Support set_pmp_deny to create invalid addresses.
+    support_set_pmp_deny = False
+
     # Internal variables:
     directory = None
     temporary_files = []

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1485,6 +1485,22 @@ class GdbTest(BaseTest):
         self.gdb.select_hart(self.hart)
         self.gdb.command(f"monitor targets {self.hart.id}")
 
+    def set_pmp_deny(self, address, size=4 * 1024):
+        # Enable physical memory protection, no permission to access specific
+        # address range (default 4KB).
+        self.gdb.p("$mseccfg=0x4")  # RLB
+        self.gdb.p("$pmpcfg0=0x98") # L, NAPOT, !R, !W, !X
+        self.gdb.p("$pmpaddr0="
+                       f"0x{((address >> 2) | ((size - 1) >> 3)):x}")
+        # PMP changes require an sfence.vma, 0x12000073 is sfence.vma
+        self.gdb.command("monitor riscv exec_progbuf 0x12000073")
+
+    def reset_pmp_deny(self):
+        self.gdb.p("$pmpcfg0=0")
+        self.gdb.p("$pmpaddr0=0")
+        # PMP changes require an sfence.vma, 0x12000073 is sfence.vma
+        self.gdb.command("monitor riscv exec_progbuf 0x12000073")
+
     def disable_pmp(self):
         # Disable physical memory protection by allowing U mode access to all
         # memory.


### PR DESCRIPTION
Some hardware has full address coverage, so set PMP to create invalid address

Change-Id: I707281626521d321aadb6cee5aea457fc5c0424d