### PR TITLE
Improve the disable_timer function

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -1110,9 +1110,9 @@ class InterruptTest(GdbSingleHartTest):
                 self.disable_timer()
                 return
 
-        self.disable_timer()
         assertGreater(interrupt_count, 1000)
         assertGreater(local, 1000)
+        self.disable_timer()
 
     def postMortem(self):
         GdbSingleHartTest.postMortem(self)

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1508,6 +1508,9 @@ class GdbTest(BaseTest):
             if interrupt:
                 self.gdb.interrupt()
             self.gdb.p("$mie=$mie & ~0x80")
+            self.gdb.p("$mstatus=$mstatus & ~0x8")
+            self.gdb.p(f"*((long long*) 0x{self.target.clint_addr + 0x4000:x})\
+                    =0x" + "f" * (self.hart.xlen // 4))
 
     def exit(self, expected_result=10):
         self.gdb.command("delete")


### PR DESCRIPTION
1. turn off mstatus.mie
2. set mtimecmp to all f, so that mip.mtip turn to 0

Change-Id: I885c50698893ae83b32db35dabc9a04b5d709483