### PR TITLE
debug: Fix nonexistent trigger registers trap handle in entry.S

### DIFF
--- a/debug/programs/entry.S
+++ b/debug/programs/entry.S
@@ -84,8 +84,9 @@ handle_reset:
   beq   t0, t1, 1b
 .p2align 2
 2:
-  # Restore mtvec
+  # Restore mtvec and mstatus
   csrw mtvec, t2
+  csrwi mstatus, 0
 
 #ifdef MULTICORE
   csrr  t0, CSR_MHARTID


### PR DESCRIPTION
In `Sv39Test`, `SV48Test`, and `SV57Test`, if the processor does not implement the trigger module, accessing the trigger csr registers will result in a trap, causing the `mpp` field in `mstatus` to be modified to machine mode. Additionally, in the original code, `mstatus` is not restored after trap, resulting in the effective privilege mode being `machine mode` in subsequent translate tests, which prevents address translation and leads to test failures.

This PR ensures that processors without implementing the trigger module can pass the tests successfully.