### PR TITLE
[debug tests] increase remotetimeout for all spike-based targets

### DIFF
--- a/debug/targets/RISC-V/spike-multi.py
+++ b/debug/targets/RISC-V/spike-multi.py
@@ -11,7 +11,7 @@ class multispike(targets.Target):
         spike64.spike64_hart(misa=0x8000000000341129, system=1),
         spike64.spike64_hart(misa=0x8000000000341129, system=1)]
     openocd_config_path = "spike-multi.cfg"
-    timeout_sec = 30
+    timeout_sec = 180
     server_timeout_sec = 120
     implements_custom_test = True
     support_hasel = False

--- a/debug/targets/RISC-V/spike32-2-hwthread.py
+++ b/debug/targets/RISC-V/spike32-2-hwthread.py
@@ -7,7 +7,7 @@ class spike32_2(targets.Target):
     harts = [spike32.spike32_hart(misa=0x40341129),
             spike32.spike32_hart(misa=0x40341129)]
     openocd_config_path = "spike-2-hwthread.cfg"
-    timeout_sec = 5
+    timeout_sec = 180
     implements_custom_test = True
     support_memory_sampling = False # not supported without sba
     support_unavailable_control = True

--- a/debug/targets/RISC-V/spike32-2.py
+++ b/debug/targets/RISC-V/spike32-2.py
@@ -7,7 +7,7 @@ class spike32_2(targets.Target):
     harts = [spike32.spike32_hart(misa=0x40141125),
             spike32.spike32_hart(misa=0x40141125)]
     openocd_config_path = "spike-2.cfg"
-    timeout_sec = 30
+    timeout_sec = 180
     implements_custom_test = True
     support_unavailable_control = True
 

--- a/debug/targets/RISC-V/spike32.py
+++ b/debug/targets/RISC-V/spike32.py
@@ -13,7 +13,7 @@ class spike32_hart(targets.Hart):
 class spike32(targets.Target):
     harts = [spike32_hart(misa=0x4034112d)]
     openocd_config_path = "spike-1.cfg"
-    timeout_sec = 30
+    timeout_sec = 180
     implements_custom_test = True
     support_memory_sampling = False # Needs SBA
     freertos_binary = "bin/RTOSDemo32.axf"

--- a/debug/targets/RISC-V/spike64-2-hwthread.py
+++ b/debug/targets/RISC-V/spike64-2-hwthread.py
@@ -7,9 +7,7 @@ class spike64_2(targets.Target):
     harts = [spike64.spike64_hart(misa=0x8000000000341129),
             spike64.spike64_hart(misa=0x8000000000341129)]
     openocd_config_path = "spike-2-hwthread.cfg"
-    # Increased timeout because we use abstract_rti to artificially slow things
-    # down.
-    timeout_sec = 20
+    timeout_sec = 180
     implements_custom_test = True
     support_hasel = False
     support_memory_sampling = False # Needs SBA

--- a/debug/targets/RISC-V/spike64-2-rtos.py
+++ b/debug/targets/RISC-V/spike64-2-rtos.py
@@ -7,7 +7,7 @@ class spike64_2_rtos(targets.Target):
     harts = [spike64.spike64_hart(misa=0x8000000000141129),
             spike64.spike64_hart(misa=0x8000000000141129)]
     openocd_config_path = "spike-rtos.cfg"
-    timeout_sec = 60
+    timeout_sec = 180
     implements_custom_test = True
     support_hasel = False
     test_semihosting = False

--- a/debug/targets/RISC-V/spike64-2.py
+++ b/debug/targets/RISC-V/spike64-2.py
@@ -7,7 +7,7 @@ class spike64_2(targets.Target):
     harts = [spike64.spike64_hart(misa=0x8000000000141129),
             spike64.spike64_hart(misa=0x8000000000141129)]
     openocd_config_path = "spike-2.cfg"
-    timeout_sec = 5
+    timeout_sec = 180
     implements_custom_test = True
     support_memory_sampling = False # Needs SBA
     support_unavailable_control = True

--- a/debug/targets/RISC-V/spike64.py
+++ b/debug/targets/RISC-V/spike64.py
@@ -14,7 +14,7 @@ class spike64_hart(targets.Hart):
 class spike64(targets.Target):
     harts = [spike64_hart()]
     openocd_config_path = "spike-1.cfg"
-    timeout_sec = 30
+    timeout_sec = 180
     implements_custom_test = True
     freertos_binary = "bin/RTOSDemo64.axf"
     support_unavailable_control = True


### PR DESCRIPTION
Spike simulator is very demanding to CPU resources. This causes debug tests to sporadically fail on slower machines. Increasing of gdb's `remotetimeout` should get rid of such failures, unless we run the testsuite on a potato.

The only downside is that if OpenOCD is broken, tests can run longer. However, I think this is the sacrifice we can make, since execution time is not affected if everything works as expected.