### PR TITLE
Debug: suppress `PRNG seed ...` log messages when `gdbserver.py --list-tests <target>` used

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -11,7 +11,6 @@ import os
 import re
 import itertools
 
-from datetime import datetime
 import targets
 import testlib
 from testlib import assertEqual, assertNotEqual
@@ -2212,16 +2211,6 @@ def main():
     testlib.print_log_names = parsed.print_log_names
 
     module = sys.modules[__name__]
-
-    # initialize PRNG
-    selected_seed = parsed.seed
-    if parsed.seed is None:
-        selected_seed = int(datetime.now().timestamp())
-        if parsed.list_tests is None:
-            print(f"PRNG seed for {target.name} is generated automatically")
-    if parsed.list_tests is None:
-        print(f"PRNG seed for {target.name} is {selected_seed}")
-    random.seed(selected_seed)
 
     return testlib.run_all_tests(module, target, parsed)
 

--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -2217,8 +2217,10 @@ def main():
     selected_seed = parsed.seed
     if parsed.seed is None:
         selected_seed = int(datetime.now().timestamp())
-        print(f"PRNG seed for {target.name} is generated automatically")
-    print(f"PRNG seed for {target.name} is {selected_seed}")
+        if parsed.list_tests is None:
+            print(f"PRNG seed for {target.name} is generated automatically")
+    if parsed.list_tests is None:
+        print(f"PRNG seed for {target.name} is {selected_seed}")
     random.seed(selected_seed)
 
     return testlib.run_all_tests(module, target, parsed)

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import os.path
+import random
 import re
 import shlex
 import subprocess
@@ -12,6 +13,8 @@ import traceback
 import tty
 import pexpect
 import yaml
+
+from datetime import datetime
 
 print_log_names = False
 real_stdout = sys.stdout
@@ -1159,6 +1162,14 @@ def run_all_tests(module, target, parsed):
 
     excluded_tests = load_excluded_tests(parsed.exclude_tests, target.name)
     target.skip_tests += excluded_tests
+
+    # initialize PRNG
+    selected_seed = parsed.seed
+    if parsed.seed is None:
+        selected_seed = int(datetime.now().timestamp())
+        print(f"PRNG seed for {target.name} is generated automatically")
+    print(f"PRNG seed for {target.name} is {selected_seed}")
+    random.seed(selected_seed)
 
     results, count = run_tests(parsed, target, todo)
 

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -10,11 +10,11 @@ import tempfile
 import time
 import traceback
 
+from datetime import datetime
+
 import tty
 import pexpect
 import yaml
-
-from datetime import datetime
 
 print_log_names = False
 real_stdout = sys.stdout
@@ -1303,7 +1303,6 @@ class BaseTest:
         if not hart is None:
             self.hart = hart
         else:
-            import random   # pylint: disable=import-outside-toplevel
             self.hart = random.choice(target.harts)
             #self.hart = target.harts[-1]
         self.server = None


### PR DESCRIPTION
`gdbserver.py --list-tests <target>` should output a list of tests for the selected target and nothing else.
An earlier PR/commit caused two `PRNG seed ...` log mesages to always be output at startup even when `--list-tests` was used.
This, in turn, caused problems with the `Makefile` driven tests.
This PR simply suppresses these `PRNG seed ...` log messages when `--list-tests` has been specified.

See here for more background:

* https://github.com/riscv-software-src/riscv-tests/pull/531#issuecomment-2151026889
* https://github.com/riscv-software-src/riscv-tests/pull/531#issuecomment-2151081139
