### PR TITLE
Add support for Zalasr unratified extension

### DIFF
--- a/isa/Makefile
+++ b/isa/Makefile
@@ -58,10 +58,10 @@ vpath %.S $(src_dir)
 	$(RISCV_OBJDUMP) $< > $@
 
 %.out: %
-	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot_zicntr_zba_zbb_zbc_zbs --misaligned $< 2> $@
+	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot_zicntr_zba_zbb_zbc_zbs_zalasr --misaligned $< 2> $@
 
 %.out32: %
-	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot_zicntr_zba_zbb_zbc_zbs --misaligned $< 2> $@
+	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot_zicntr_zba_zbb_zbc_zbs_zalasr --misaligned $< 2> $@
 
 define compile_template
 

--- a/isa/rv32ua/Makefrag
+++ b/isa/rv32ua/Makefrag
@@ -4,7 +4,7 @@
 
 rv32ua_sc_tests = \
 	amoadd_w amoand_w amomax_w amomaxu_w amomin_w amominu_w amoor_w amoxor_w amoswap_w \
-	lrsc \
+	lrsc zalasr \
 
 rv32ua_p_tests = $(addprefix rv32ua-p-, $(rv32ua_sc_tests))
 rv32ua_v_tests = $(addprefix rv32ua-v-, $(rv32ua_sc_tests))

--- a/isa/rv32ua/zalasr.S
+++ b/isa/rv32ua/zalasr.S
@@ -1,0 +1,45 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# zalasr.S
+#-----------------------------------------------------------------------------
+#
+# Test zalasr instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  TEST_LD_OP( 1, lb.aq  , 0x0000000000000008, 0, tdat );
+  TEST_LD_OP( 2, lb.aqrl, 0x0000000000000008, 0, tdat );
+  TEST_LD_OP( 3, lh.aq  , 0x0000000000000708, 0, tdat );
+  TEST_LD_OP( 4, lh.aqrl, 0x0000000000000708, 0, tdat );
+  TEST_LD_OP( 5, lw.aq  , 0x0000000005060708, 0, tdat );
+  TEST_LD_OP( 6, lw.aqrl, 0x0000000005060708, 0, tdat );
+
+
+  TEST_ST_OP(11, lb, sb.rl  , 0x0000000000000008, 0, tdat );
+  TEST_ST_OP(12, lb, sb.aqrl, 0x0000000000000008, 0, tdat );
+  TEST_ST_OP(13, lh, sh.rl  , 0x0000000000000708, 0, tdat );
+  TEST_ST_OP(14, lh, sh.aqrl, 0x0000000000000708, 0, tdat );
+  TEST_ST_OP(15, lw, sw.rl  , 0x0000000005060708, 0, tdat );
+  TEST_ST_OP(16, lw, sw.aqrl, 0x0000000005060708, 0, tdat );
+  
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+  .align 3
+tdat:
+  .dword 0x0102030405060708
+
+RVTEST_DATA_END

--- a/isa/rv64ua/Makefrag
+++ b/isa/rv64ua/Makefrag
@@ -5,7 +5,7 @@
 rv64ua_sc_tests = \
 	amoadd_d amoand_d amomax_d amomaxu_d amomin_d amominu_d amoor_d amoxor_d amoswap_d \
 	amoadd_w amoand_w amomax_w amomaxu_w amomin_w amominu_w amoor_w amoxor_w amoswap_w \
-	lrsc \
+	lrsc zalasr \
 
 rv64ua_p_tests = $(addprefix rv64ua-p-, $(rv64ua_sc_tests))
 rv64ua_v_tests = $(addprefix rv64ua-v-, $(rv64ua_sc_tests))

--- a/isa/rv64ua/zalasr.S
+++ b/isa/rv64ua/zalasr.S
@@ -1,0 +1,49 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# zalasr.S
+#-----------------------------------------------------------------------------
+#
+# Test zalasr instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  TEST_LD_OP( 1, lb.aq  , 0x0000000000000008, 0, tdat );
+  TEST_LD_OP( 2, lb.aqrl, 0x0000000000000008, 0, tdat );
+  TEST_LD_OP( 3, lh.aq  , 0x0000000000000708, 0, tdat );
+  TEST_LD_OP( 4, lh.aqrl, 0x0000000000000708, 0, tdat );
+  TEST_LD_OP( 5, lw.aq  , 0x0000000005060708, 0, tdat );
+  TEST_LD_OP( 6, lw.aqrl, 0x0000000005060708, 0, tdat );
+  TEST_LD_OP( 7, ld.aq  , 0x0102030405060708, 0, tdat );
+  TEST_LD_OP( 8, ld.aqrl, 0x0102030405060708, 0, tdat );
+
+
+  TEST_ST_OP(11, lb, sb.rl  , 0x0000000000000008, 0, tdat );
+  TEST_ST_OP(12, lb, sb.aqrl, 0x0000000000000008, 0, tdat );
+  TEST_ST_OP(13, lh, sh.rl  , 0x0000000000000708, 0, tdat );
+  TEST_ST_OP(14, lh, sh.aqrl, 0x0000000000000708, 0, tdat );
+  TEST_ST_OP(15, lw, sw.rl  , 0x0000000005060708, 0, tdat );
+  TEST_ST_OP(16, lw, sw.aqrl, 0x0000000005060708, 0, tdat );
+  TEST_ST_OP(17, ld, sd.rl  , 0x0102030405060708, 0, tdat );
+  TEST_ST_OP(18, ld, sd.aqrl, 0x0102030405060708, 0, tdat );
+  
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+  .align 3
+tdat:
+  .dword 0x0102030405060708
+
+RVTEST_DATA_END


### PR DESCRIPTION
Based on https://github.com/riscv-software-src/riscv-tests/pull/492.
I was able to test it with my hacked-up clang/spike and makefiles, so I don't think this can be merged until my patches for them are merged.
Specification is available at https://github.com/riscv/riscv-zalasr