### PR TITLE
Debug: use correct Spike DTM IDCODE in OpenOCD scripts

### DIFF
--- a/debug/targets/RISC-V/spike-1.cfg
+++ b/debug/targets/RISC-V/spike-1.cfg
@@ -5,7 +5,7 @@ remote_bitbang host $::env(REMOTE_BITBANG_HOST)
 remote_bitbang port $::env(REMOTE_BITBANG_PORT)
 
 set _CHIPNAME riscv
-jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0xdeadbeef
 
 set _TARGETNAME $_CHIPNAME.cpu
 if {$::env(USE_FREERTOS)} {

--- a/debug/targets/RISC-V/spike-2-hwthread.cfg
+++ b/debug/targets/RISC-V/spike-2-hwthread.cfg
@@ -6,7 +6,7 @@ remote_bitbang host $::env(REMOTE_BITBANG_HOST)
 remote_bitbang port $::env(REMOTE_BITBANG_PORT)
 
 set _CHIPNAME riscv
-jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0xdeadbeef
 
 set _TARGETNAME_0 $_CHIPNAME.cpu0
 set _TARGETNAME_1 $_CHIPNAME.cpu1

--- a/debug/targets/RISC-V/spike-2.cfg
+++ b/debug/targets/RISC-V/spike-2.cfg
@@ -6,7 +6,7 @@ remote_bitbang host $::env(REMOTE_BITBANG_HOST)
 remote_bitbang port $::env(REMOTE_BITBANG_PORT)
 
 set _CHIPNAME riscv
-jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0xdeadbeef
 
 set _TARGETNAME_0 $_CHIPNAME.cpu0
 set _TARGETNAME_1 $_CHIPNAME.cpu1

--- a/debug/targets/RISC-V/spike-multi.cfg
+++ b/debug/targets/RISC-V/spike-multi.cfg
@@ -5,8 +5,8 @@ adapter driver remote_bitbang
 remote_bitbang host $::env(REMOTE_BITBANG_HOST)
 remote_bitbang port $::env(REMOTE_BITBANG_PORT)
 
-jtag newtap riscv.0 cpu -irlen 5 -expected-id 0x10e31913
-jtag newtap riscv.1 cpu -irlen 5 -expected-id 0x10e31913
+jtag newtap riscv.0 cpu -irlen 5 -expected-id 0xdeadbeef
+jtag newtap riscv.1 cpu -irlen 5 -expected-id 0xdeadbeef
 
 target create riscv.0.cpu0 riscv -chain-position riscv.0.cpu -coreid 0
 target create riscv.0.cpu1 riscv -chain-position riscv.0.cpu -coreid 1


### PR DESCRIPTION
Addresses this issue:

- https://github.com/riscv-software-src/riscv-tests/issues/563

Changed the IDCODE in the Spike target scripts from SiFive HiFive's `0x10e31913` to Spike's `0xdeadbeef`.
This eliminates the distracting and avoidable warning/error messages resulting from the mismatch between the expected and actual IDCODEs.
The differences are highlighted using asterisks in the logs below.

Before change:
```
-------------------------[ /tmp/openocd12wdc0r4.log ]-------------------------
+ REMOTE_BITBANG_HOST=localhost REMOTE_BITBANG_PORT=45185 WORK_AREA=0x1212340000 USE_FREERTOS=0 openocd --command 'gdb_port 0' --command 'tcl_port 0' --command 'telnet_port disabled' -f targets/RISC-V/spike-1.cfg
Open On-Chip Debugger 0.12.0+dev-03808-g40cda81e8 (2024-06-06-14:13)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
Info : Initializing remote_bitbang driver
Info : Connecting to localhost:45185
Info : remote_bitbang driver initialized
Info : Note: The adapter "remote_bitbang" doesn't support configurable speed
*******************************************************************************************************************
Info : JTAG tap: riscv.cpu tap/device found: 0xdeadbeef (mfg: 0x777 (Fabric of Truth Inc), part: 0xeadb, ver: 0xd)
Warn : JTAG tap: riscv.cpu       UNEXPECTED: 0xdeadbeef (mfg: 0x777 (Fabric of Truth Inc), part: 0xeadb, ver: 0xd)
Error: JTAG tap: riscv.cpu  expected 1 of 1: 0x10e31913 (mfg: 0x489 (SiFive Inc), part: 0x0e31, ver: 0x1)
Error: Trying to use configured scan chain anyway...
Warn : Bypassing JTAG setup events due to errors
*******************************************************************************************************************
Error: Debugger is not authenticated to target Debug Module. (dmstatus=0x4c0c02). Use `riscv authdata_read` and `riscv authdata_write` commands to authenticate.
Error: [riscv.cpu] Examination failed
Warn : target riscv.cpu examination failed
Info : starting gdb server for riscv.cpu on 0
Info : Listening on port 39917 for gdb connections
Info : [riscv.cpu] authdata_write resulted in successful authentication
Info : [riscv.cpu] datacount=2 progbufsize=0
Warn : [riscv.cpu] We won't be able to execute fence instructions on this target. Memory may not always appear consistent. (progbufsize=0, impebreak=1)
Error: [riscv.cpu] Unable to insert program into progbuf, capacity would be exceeded (progbufsize=0).
Error: [riscv.cpu] Unable to insert program into progbuf, capacity would be exceeded (progbufsize=0).
Info : [riscv.cpu] Examined RISC-V core
Info : [riscv.cpu]  XLEN=64, misa=0x8000000000141125
[riscv.cpu] Target successfully examined.
Info : [riscv.cpu] Examination succeed
riscv.cpu halted due to debug-request.
semihosting is enabled
Info : Listening on port 44249 for tcl connections
Info : telnet server disabled
Info : accepting 'tcl' connection on tcp/0
Hello TCL-RPC!
Hello TCL-RPC!

Info : accepting 'gdb' connection on tcp/0
riscv.cpu halted due to debug-request. Semihosting is active.
Info : dropped 'gdb' connection
shutdown command invoked
Info : remote_bitbang interface quit
```
After change:
```
-------------------------[ /tmp/openocdunt3hlws.log ]-------------------------
+ REMOTE_BITBANG_HOST=localhost REMOTE_BITBANG_PORT=45839 WORK_AREA=0x1212340000 USE_FREERTOS=0 openocd --command 'gdb_port 0' --command 'tcl_port 0' --command 'telnet_port disabled' -f targets/RISC-V/spike-1.cfg
Open On-Chip Debugger 0.12.0+dev-03808-g40cda81e8 (2024-06-06-14:13)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
Info : Initializing remote_bitbang driver
Info : Connecting to localhost:45839
Info : remote_bitbang driver initialized
Info : Note: The adapter "remote_bitbang" doesn't support configurable speed
*******************************************************************************************************************
Info : JTAG tap: riscv.cpu tap/device found: 0xdeadbeef (mfg: 0x777 (Fabric of Truth Inc), part: 0xeadb, ver: 0xd)
*******************************************************************************************************************
Error: Debugger is not authenticated to target Debug Module. (dmstatus=0x4c0c02). Use `riscv authdata_read` and `riscv authdata_write` commands to authenticate.
Error: [riscv.cpu] Examination failed
Warn : target riscv.cpu examination failed
Info : starting gdb server for riscv.cpu on 0
Info : Listening on port 33123 for gdb connections
Info : [riscv.cpu] authdata_write resulted in successful authentication
Info : [riscv.cpu] datacount=2 progbufsize=0
Warn : [riscv.cpu] We won't be able to execute fence instructions on this target. Memory may not always appear consistent. (progbufsize=0, impebreak=1)
Error: [riscv.cpu] Unable to insert program into progbuf, capacity would be exceeded (progbufsize=0).
Error: [riscv.cpu] Unable to insert program into progbuf, capacity would be exceeded (progbufsize=0).
Info : [riscv.cpu] Examined RISC-V core
Info : [riscv.cpu]  XLEN=64, misa=0x8000000000141125
[riscv.cpu] Target successfully examined.
Info : [riscv.cpu] Examination succeed
riscv.cpu halted due to debug-request.
semihosting is enabled
Info : Listening on port 42877 for tcl connections
Info : telnet server disabled
Info : accepting 'tcl' connection on tcp/0
Hello TCL-RPC!
Hello TCL-RPC!

Info : accepting 'gdb' connection on tcp/0
riscv.cpu halted due to debug-request. Semihosting is active.
Info : dropped 'gdb' connection
shutdown command invoked
Info : remote_bitbang interface quit
```
To validate this change I ran the [`Makefile`](https://github.com/riscv-software-src/riscv-tests/blob/master/debug/Makefile) driven ["smoke tests"](https://github.com/riscv-software-src/riscv-tests/tree/master/debug#usage) against Spike to ensure that there was no impact other than the elimination of the "expected IDCODE" related warnings/error log messages.