### PR TITLE
Benchmarks: parameterise ABI based on XLEN

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -6,6 +6,13 @@
 
 XLEN ?= 64
 
+ifeq ($(XLEN),32)
+ABI ?= ilp32d
+endif
+ifeq ($(XLEN),64)
+ABI ?= lp64d
+endif
+
 default: all
 
 src_dir = .
@@ -43,7 +50,7 @@ bmarks = \
 
 RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
-RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -march=rv$(XLEN)gcv -mabi=lp64d
+RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -march=rv$(XLEN)gcv -mabi=$(ABI)
 RISCV_LINK ?= $(RISCV_GCC) -T $(src_dir)/common/test.ld $(incs)
 RISCV_LINK_OPTS ?= -static -nostdlib -nostartfiles -lm -lgcc -T $(src_dir)/common/test.ld
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data


### PR DESCRIPTION
Addresses this issue:

- https://github.com/riscv-software-src/riscv-tests/issues/546

Parameterise `ABI` based on selected `XLEN` unless it has already been passed in.

Note that since `RISCV_PREFIX` has always been parameterised using `XLEN`, this means that `XLEN == 32` expects, by default, to use a `riscv32-unknown-elf-` prefixed toolchain. If necessary, this can be overridden as follows:
```
./configure ... --with-xlen=32
make benchmarks RISCV_PREFIX=riscv64-unknown-elf-
```
Obviously, whatever toolchain prefix is used the toolchain needs to support the selected `arch/abi` - e.g. `rv64gcv/lp64d` or `rv32gcv/ilp32d` or whatever other `ABI` is passed in - via the toolchain's default `arch/abi` or via multilibs for the selected `arch/abi`.

I didn't consider `XLEN == 128` since, as far as I can see, it isn't considered elswhere in the test suite but it would be trivial to extend this mod to cover it if necessary.

