### PR TITLE
[debug] Reserve the trigger in `HwbpManual`

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -711,6 +711,8 @@ class HwbpManual(DebugTest):
             self.gdb.p("$tdata1=0")
             tselect += 1
 
+        self.gdb.command(f"monitor riscv reserve_trigger {tselect}")
+
         # The breakpoint should be hit exactly 2 times.
         for _ in range(2):
             output = self.gdb.c(ops=2)


### PR DESCRIPTION
After https://github.com/riscv-collab/riscv-openocd/pull/1111 is merged, the registers a user wishes to have direct control of should be reserved.
This is the case in `HwbpManual`.

The test still works with older OpenOCD versions, since no exception is generated when a command (`riscv reserve_trigger` in this case) is not found.