### PR TITLE
syscalls: avoid -Wformat warning

### DIFF
--- a/benchmarks/common/syscalls.c
+++ b/benchmarks/common/syscalls.c
@@ -115,7 +115,7 @@ void _init(int cid, int nc)
   char* pbuf = buf;
   for (int i = 0; i < NUM_COUNTERS; i++)
     if (counters[i])
-      pbuf += sprintf(pbuf, "%s = %d\n", counter_names[i], counters[i]);
+      pbuf += sprintf(pbuf, "%s = %zd\n", counter_names[i], counters[i]);
   if (pbuf != buf)
     printstr(buf);
 


### PR DESCRIPTION
For printing uintptr_t use %zd.

    benchmarks/common/syscalls.c: In function ‘_init’:
    benchmarks/common/syscalls.c:118:36: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘uintptr_t’ {aka ‘long unsigned int’} [-Wformat=]
      118 |       pbuf += sprintf(pbuf, "%s = %d\n", counter_names[i], counters[i]);
          |                                   ~^                       ~~~~~~~~~~~
          |                                    |                               |
          |                                    int                             uintptr_t {aka long unsigned int}
          |                                   %ld