### PR TITLE
Fit riscv-tests to newest riscv spec: renaming sptbr,sbadaddr,mbadaddr

### DIFF
--- a/isa/rv64mi/illegal.S
+++ b/isa/rv64mi/illegal.S
@@ -72,19 +72,19 @@ msip:
   beqz t2, bare_s_1
   csrc sstatus, t0
 
-  # Make sure SFENCE.VMA and sptbr don't trap when TVM=0.
+  # Make sure SFENCE.VMA and satp don't trap when TVM=0.
   sfence.vma
-  csrr t0, sptbr
+  csrr t0, satp
 bad5:
   .word 0
   j fail
 
 bad6:
-  # Make sure SFENCE.VMA and sptbr do trap when TVM=1.
+  # Make sure SFENCE.VMA and satp do trap when TVM=1.
   sfence.vma
   j fail
 bad7:
-  csrr t0, sptbr
+  csrr t0, satp
   j fail
 
 test_tsr:
@@ -120,7 +120,7 @@ bare_s_2:
   j fail
 
   # And access to satp should not trap
-  csrr t0, sptbr
+  csrr t0, satp
 bare_s_3:
   .word 0
   j fail
@@ -156,7 +156,7 @@ synchronous_exception:
   csrr t0, mepc
 
   # Make sure mtval contains either 0 or the instruction word.
-  csrr t2, mbadaddr
+  csrr t2, mtval
   beqz t2, 1f
   lhu t1, 0(t0)
   xor t2, t2, t1

--- a/isa/rv64mi/ma_addr.S
+++ b/isa/rv64mi/ma_addr.S
@@ -103,7 +103,7 @@ mtvec_handler:
   j fail
 1:
 
-  csrr t0, mbadaddr
+  csrr t0, mtval
   beqz t0, 1f
   bne t0, t1, fail
 

--- a/isa/rv64si/dirty.S
+++ b/isa/rv64si/dirty.S
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
   la a1, page_table_1
   srl a1, a1, RISCV_PGSHIFT
   or a1, a1, a0
-  csrw sptbr, a1
+  csrw satp, a1
   sfence.vma
 
   # Set up MPRV with MPP=S, so loads and stores use S-mode

--- a/isa/rv64si/icache-alias.S
+++ b/isa/rv64si/icache-alias.S
@@ -48,7 +48,7 @@ RVTEST_CODE_BEGIN
   la a1, page_table_1
   srl a1, a1, RISCV_PGSHIFT
   or a1, a1, a0
-  csrw sptbr, a1
+  csrw satp, a1
   sfence.vma
 
   # Enter supervisor mode and make sure correct page is accessed

--- a/isa/rv64si/ma_fetch.S
+++ b/isa/rv64si/ma_fetch.S
@@ -17,7 +17,7 @@ RVTEST_CODE_BEGIN
   #define sscratch mscratch
   #define sstatus mstatus
   #define scause mcause
-  #define sbadaddr mbadaddr
+  #define stval mtval
   #define sepc mepc
   #define sret mret
   #define stvec_handler mtvec_handler
@@ -205,8 +205,8 @@ stvec_handler:
   addi a1, a1, 4
   bne t0, a1, fail
 
-  # verify that badaddr == 0 or badaddr == t0+2.
-  csrr a0, sbadaddr
+  # verify that tval == 0 or tval == t0+2.
+  csrr a0, stval
   beqz a0, 1f
   addi a0, a0, -2
   bne a0, t0, fail


### PR DESCRIPTION
issue#577

In the newest riscv spec(2021 or later), two csr register "sptbr"(0x180) "s/mbadaddr"(0x243) were removed,
and upgraded to "satp" "s/mtval". Together with more functions.

This commit rename them to pass compile.