### PR TITLE
Suppress implicit-int and implicit-function-declaration warnings in Dhrystone

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -50,7 +50,7 @@ bmarks = \
 
 RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
-RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -march=rv$(XLEN)gcv -mabi=$(ABI)
+RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -Wno-implicit-int -Wno-implicit-function-declaration -march=rv$(XLEN)gcv -mabi=$(ABI)
 RISCV_LINK ?= $(RISCV_GCC) -T $(src_dir)/common/test.ld $(incs)
 RISCV_LINK_OPTS ?= -static -nostdlib -nostartfiles -lm -lgcc -T $(src_dir)/common/test.ld
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data


### PR DESCRIPTION
Add `-Wno-implicit-int -Wno-implicit-function-declaration` to the benchmarks directory's `Makefile` in order to suppress these warnings which are triggered by the Dhrystone source code and which are treated as non-fatal warnings in GCC 13 and earlier but as fatal errors in GCC 14.

Only Dhrystone triggers these warnings but the flags are global to all benchmarks. I'm assuming that this is OK and that refactoring of the benchmarks `Makefile` to make these apply only to Dhrystone is not necessary?

Another PR (#585) was proposed (see below) but that takes the approach of "fixing" the Dhrystone code and, as @aswaterman pointed out [here](https://github.com/riscv-software-src/riscv-tests/pull/585#pullrequestreview-2379150160), the Dhrystone benchmark source code is not supposed to be modified but, rather, to be used as-is.

See also:

- Previous PR which should be rendered moot by this one: https://github.com/riscv-software-src/riscv-tests/pull/585
- https://github.com/riscv-software-src/riscv-tests/issues/584
- https://github.com/riscv-software-src/riscv-tests/issues/560
- https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1600

Prior to this PR here is the behaviour with GCC 13 and 14:
```
# GCC 13

riscv64-unknown-elf-gcc -I/home/user/riscv-tests/riscv-tests/benchmarks/../env -I/home/user/riscv-tests/riscv-tests/benchmarks/common -I/home/user/riscv-tests/riscv-tests/benchmarks/median -I/home/user/riscv-tests/riscv-tests/benchmarks/qsort -I/home/user/riscv-tests/riscv-tests/benchmarks/rsort -I/home/user/riscv-tests/riscv-tests/benchmarks/towers -I/home/user/riscv-tests/riscv-tests/benchmarks/vvadd -I/home/user/riscv-tests/riscv-tests/benchmarks/memcpy -I/home/user/riscv-tests/riscv-tests/benchmarks/multiply -I/home/user/riscv-tests/riscv-tests/benchmarks/mm -I/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone -I/home/user/riscv-tests/riscv-tests/benchmarks/spmv -I/home/user/riscv-tests/riscv-tests/benchmarks/mt-vvadd -I/home/user/riscv-tests/riscv-tests/benchmarks/mt-matmul -I/home/user/riscv-tests/riscv-tests/benchmarks/mt-memcpy -I/home/user/riscv-tests/riscv-tests/benchmarks/pmp -I/home/user/riscv-tests/riscv-tests/benchmarks/vec-memcpy -I/home/user/riscv-tests/riscv-tests/benchmarks/vec-daxpy -I/home/user/riscv-tests/riscv-tests/benchmarks/vec-sgemm -I/home/user/riscv-tests/riscv-tests/benchmarks/vec-strcmp -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -march=rv64gcv -mabi=lp64d -o dhrystone.riscv /home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c /home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c  /home/user/riscv-tests/riscv-tests/benchmarks/common/syscalls.c /home/user/riscv-tests/riscv-tests/benchmarks/common/crt.S -static -nostdlib -nostartfiles -lm -lgcc -T /home/user/riscv-tests/riscv-tests/benchmarks/common/test.ld
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c:20:1: warning: return type defaults to 'int' [-Wimplicit-int]
   20 | Proc_6 (Enum_Val_Par, Enum_Ref_Par)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c: In function 'Proc_6':
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c:29:9: warning: implicit declaration of function 'Func_3' [-Wimplicit-function-declaration]
   29 |   if (! Func_3 (Enum_Val_Par))
      |         ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c: At top level:
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c:54:1: warning: return type defaults to 'int' [-Wimplicit-int]
   54 | Proc_7 (Int_1_Par_Val, Int_2_Par_Val, Int_Par_Ref)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c:74:1: warning: return type defaults to 'int' [-Wimplicit-int]
   74 | Proc_8 (Arr_1_Par_Ref, Arr_2_Par_Ref, Int_1_Par_Val, Int_2_Par_Val)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: In function 'main':
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:120:7: warning: implicit declaration of function 'Proc_5' [-Wimplicit-function-declaration]
  120 |       Proc_5();
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:121:7: warning: implicit declaration of function 'Proc_4' [-Wimplicit-function-declaration]
  121 |       Proc_4();
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:127:21: warning: implicit declaration of function 'Func_2'; did you mean 'Func_1'? [-Wimplicit-function-declaration]
  127 |       Bool_Glob = ! Func_2 (Str_1_Loc, Str_2_Loc);
      |                     ^~~~~~
      |                     Func_1
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:133:9: warning: implicit declaration of function 'Proc_7' [-Wimplicit-function-declaration]
  133 |         Proc_7 (Int_1_Loc, Int_2_Loc, &Int_3_Loc);
      |         ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:138:7: warning: implicit declaration of function 'Proc_8' [-Wimplicit-function-declaration]
  138 |       Proc_8 (Arr_1_Glob, Arr_2_Glob, Int_1_Loc, Int_3_Loc);
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:140:7: warning: implicit declaration of function 'Proc_1' [-Wimplicit-function-declaration]
  140 |       Proc_1 (Ptr_Glob);
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:147:11: warning: implicit declaration of function 'Proc_6' [-Wimplicit-function-declaration]
  147 |           Proc_6 (Ident_1, &Enum_Loc);
      |           ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:158:7: warning: implicit declaration of function 'Proc_2' [-Wimplicit-function-declaration]
  158 |       Proc_2 (&Int_1_Loc);
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: At top level:
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:242:1: warning: return type defaults to 'int' [-Wimplicit-int]
  242 | Proc_1 (Ptr_Val_Par)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: In function 'Proc_1':
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:258:3: warning: implicit declaration of function 'Proc_3'; did you mean 'Proc_1'? [-Wimplicit-function-declaration]
  258 |   Proc_3 (&Next_Record->Ptr_Comp);
      |   ^~~~~~
      |   Proc_1
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: At top level:
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:276:1: warning: return type defaults to 'int' [-Wimplicit-int]
  276 | Proc_2 (Int_Par_Ref)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:299:1: warning: return type defaults to 'int' [-Wimplicit-int]
  299 | Proc_3 (Ptr_Ref_Par)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:314:1: warning: return type defaults to 'int' [-Wimplicit-int]
  314 | Proc_4 () /* without parameters */
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:326:1: warning: return type defaults to 'int' [-Wimplicit-int]
  326 | Proc_5 () /* without parameters */
      | ^~~~~~

# GCC 14

riscv64-unknown-elf-gcc -I/home/user/riscv-tests/riscv-tests/benchmarks/../env -I/home/user/riscv-tests/riscv-tests/benchmarks/common -I/home/user/riscv-tests/riscv-tests/benchmarks/median -I/home/user/riscv-tests/riscv-tests/benchmarks/qsort -I/home/user/riscv-tests/riscv-tests/benchmarks/rsort -I/home/user/riscv-tests/riscv-tests/benchmarks/towers -I/home/user/riscv-tests/riscv-tests/benchmarks/vvadd -I/home/user/riscv-tests/riscv-tests/benchmarks/memcpy -I/home/user/riscv-tests/riscv-tests/benchmarks/multiply -I/home/user/riscv-tests/riscv-tests/benchmarks/mm -I/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone -I/home/user/riscv-tests/riscv-tests/benchmarks/spmv -I/home/user/riscv-tests/riscv-tests/benchmarks/mt-vvadd -I/home/user/riscv-tests/riscv-tests/benchmarks/mt-matmul -I/home/user/riscv-tests/riscv-tests/benchmarks/mt-memcpy -I/home/user/riscv-tests/riscv-tests/benchmarks/pmp -I/home/user/riscv-tests/riscv-tests/benchmarks/vec-memcpy -I/home/user/riscv-tests/riscv-tests/benchmarks/vec-daxpy -I/home/user/riscv-tests/riscv-tests/benchmarks/vec-sgemm -I/home/user/riscv-tests/riscv-tests/benchmarks/vec-strcmp -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -march=rv64gcv -mabi=lp64d -o dhrystone.riscv /home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c /home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c  /home/user/riscv-tests/riscv-tests/benchmarks/common/syscalls.c /home/user/riscv-tests/riscv-tests/benchmarks/common/crt.S -static -nostdlib -nostartfiles -lm -lgcc -T /home/user/riscv-tests/riscv-tests/benchmarks/common/test.ld
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c:20:1: error: return type defaults to 'int' [-Wimplicit-int]
   20 | Proc_6 (Enum_Val_Par, Enum_Ref_Par)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c: In function 'Proc_6':
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c:29:9: error: implicit declaration of function 'Func_3' [-Wimplicit-function-declaration]
   29 |   if (! Func_3 (Enum_Val_Par))
      |         ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c: At top level:
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c:54:1: error: return type defaults to 'int' [-Wimplicit-int]
   54 | Proc_7 (Int_1_Par_Val, Int_2_Par_Val, Int_Par_Ref)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone.c:74:1: error: return type defaults to 'int' [-Wimplicit-int]
   74 | Proc_8 (Arr_1_Par_Ref, Arr_2_Par_Ref, Int_1_Par_Val, Int_2_Par_Val)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: In function 'main':
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:120:7: error: implicit declaration of function 'Proc_5' [-Wimplicit-function-declaration]
  120 |       Proc_5();
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:121:7: error: implicit declaration of function 'Proc_4' [-Wimplicit-function-declaration]
  121 |       Proc_4();
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:127:21: error: implicit declaration of function 'Func_2'; did you mean 'Func_1'? [-Wimplicit-function-declaration]
  127 |       Bool_Glob = ! Func_2 (Str_1_Loc, Str_2_Loc);
      |                     ^~~~~~
      |                     Func_1
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:133:9: error: implicit declaration of function 'Proc_7' [-Wimplicit-function-declaration]
  133 |         Proc_7 (Int_1_Loc, Int_2_Loc, &Int_3_Loc);
      |         ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:138:7: error: implicit declaration of function 'Proc_8' [-Wimplicit-function-declaration]
  138 |       Proc_8 (Arr_1_Glob, Arr_2_Glob, Int_1_Loc, Int_3_Loc);
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:140:7: error: implicit declaration of function 'Proc_1' [-Wimplicit-function-declaration]
  140 |       Proc_1 (Ptr_Glob);
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:147:11: error: implicit declaration of function 'Proc_6' [-Wimplicit-function-declaration]
  147 |           Proc_6 (Ident_1, &Enum_Loc);
      |           ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:158:7: error: implicit declaration of function 'Proc_2' [-Wimplicit-function-declaration]
  158 |       Proc_2 (&Int_1_Loc);
      |       ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: At top level:
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:242:1: error: return type defaults to 'int' [-Wimplicit-int]
  242 | Proc_1 (Ptr_Val_Par)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: In function 'Proc_1':
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:258:3: error: implicit declaration of function 'Proc_3'; did you mean 'Proc_1'? [-Wimplicit-function-declaration]
  258 |   Proc_3 (&Next_Record->Ptr_Comp);
      |   ^~~~~~
      |   Proc_1
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: At top level:
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:276:1: error: return type defaults to 'int' [-Wimplicit-int]
  276 | Proc_2 (Int_Par_Ref)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:299:1: error: return type defaults to 'int' [-Wimplicit-int]
  299 | Proc_3 (Ptr_Ref_Par)
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:314:1: error: return type defaults to 'int' [-Wimplicit-int]
  314 | Proc_4 () /* without parameters */
      | ^~~~~~
/home/user/riscv-tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:326:1: error: return type defaults to 'int' [-Wimplicit-int]
  326 | Proc_5 () /* without parameters */
      | ^~~~~~
make[1]: *** [/home/user/riscv-tests/riscv-tests/benchmarks/Makefile:67: dhrystone.riscv] Error 1
make[1]: Leaving directory '/home/user/riscv-tests/riscv-tests/benchmarks'
make: *** [Makefile:25: benchmarks] Error 2
```
After this change compilation of Dhrystone using GCC 14 succeeds.
```
riscv64-unknown-elf-gcc -I./../env -I./common -I./median -I./qsort -I./rsort -I./towers -I./vvadd -I./memcpy -I./multiply -I./mm -I./dhrystone -I./spmv -I./mt-vvadd -I./mt-matmul -I./mt-memcpy -I./pmp -I./vec-memcpy -I./vec-daxpy -I./vec-sgemm -I./vec-strcmp -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -Wno-implicit-int -Wno-implicit-function-declaration -march=rv64gcv -mabi=lp64d -o dhrystone.riscv ./dhrystone/dhrystone.c ./dhrystone/dhrystone_main.c  ./common/syscalls.c ./common/crt.S -static -nostdlib -nostartfiles -lm -lgcc -T ./common/test.ld
/home/user/riscv-gnu-toolchain/installed-tools/lib/gcc/riscv64-unknown-elf/14.2.0/../../../../riscv64-unknown-elf/bin/ld: warning: dhrystone.riscv has a LOAD segment with RWX permissions
riscv64-unknown-elf-objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data dhrystone.riscv > dhrystone.riscv.dump
```