### PR TITLE
Fix the typo in the Makefrag for the reference to 2-stage-translation.S

### DIFF
--- a/isa/hypervisor/Makefrag
+++ b/isa/hypervisor/Makefrag
@@ -3,6 +3,6 @@
 #-----------------------------------------------------------------------
 
 hypervisor_sc_tests = \
-	2-stage-translation \
+	2-stage_translation \
 
 hypervisor_p_tests = $(addprefix hypervisor-p-, $(hypervisor_sc_tests))


### PR DESCRIPTION
I want to test the stage-2 tests in the `riscv-tests`
The error message is as follows:
```
make[1]: *** No rule to make target 'hypervisor/2-stage-translation.S', needed by 'hypervisor-p-2-stage-translation'.  Stop.
```
After correcting the name `2-stage-translation`  in `isa/hypervisor/Makefrag`, everything is working well fine for me.
```
riscv64-unknown-elf-gcc -march=rv64gh -mabi=lp64 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I/home/porterlu/tmp/riscv-tests/isa/../env/p -I/home/porterlu/tmp/riscv-tests/isa/macros/scalar -T/home/porterlu/tmp/riscv-tests/isa/../env/p/link.ld hypervisor/2-stage_translation.S -o hypervisor-p-2-stage_translation
```
