### PR TITLE
Compile non-vec benchmarks for rv64gc

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -24,7 +24,7 @@ instbasedir = $(UCB_VLSI_HOME)/install
 # Sources
 #--------------------------------------------------------------------
 
-bmarks = \
+base_bmarks = \
 	median \
 	qsort \
 	rsort \
@@ -39,10 +39,14 @@ bmarks = \
 	mt-matmul \
 	mt-memcpy \
 	pmp \
+
+vec_bmarks = \
 	vec-memcpy \
 	vec-daxpy \
 	vec-sgemm \
 	vec-strcmp \
+
+bmarks = $(base_bmarks) $(vec_bmarks)
 
 #--------------------------------------------------------------------
 # Build rules
@@ -50,10 +54,12 @@ bmarks = \
 
 RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
-RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -Wno-implicit-int -Wno-implicit-function-declaration -march=rv$(XLEN)gcv -mabi=$(ABI)
+RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -Wno-implicit-int -Wno-implicit-function-declaration -mabi=$(ABI)
 RISCV_LINK ?= $(RISCV_GCC) -T $(src_dir)/common/test.ld $(incs)
 RISCV_LINK_OPTS ?= -static -nostdlib -nostartfiles -lm -lgcc -T $(src_dir)/common/test.ld
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data
+RISCV_MARCH ?= rv$(XLEN)gc
+RISCV_VMARCH ?= rv$(XLEN)gcv
 RISCV_SIM ?= spike --isa=rv$(XLEN)gcv
 
 incs  += -I$(src_dir)/../env -I$(src_dir)/common $(addprefix -I$(src_dir)/, $(bmarks))
@@ -61,10 +67,11 @@ objs  :=
 
 define compile_template
 $(1).riscv: $(wildcard $(src_dir)/$(1)/*) $(wildcard $(src_dir)/common/*)
-	$$(RISCV_GCC) $$(incs) $$(RISCV_GCC_OPTS) -o $$@ $(wildcard $(src_dir)/$(1)/*.c) $(wildcard $(src_dir)/$(1)/*.S) $(wildcard $(src_dir)/common/*.c) $(wildcard $(src_dir)/common/*.S) $$(RISCV_LINK_OPTS)
+	$$(RISCV_GCC) $$(incs) $$(RISCV_GCC_OPTS) -march=$(2) -o $$@ $(wildcard $(src_dir)/$(1)/*.c) $(wildcard $(src_dir)/$(1)/*.S) $(wildcard $(src_dir)/common/*.c) $(wildcard $(src_dir)/common/*.S) $$(RISCV_LINK_OPTS)
 endef
 
-$(foreach bmark,$(bmarks),$(eval $(call compile_template,$(bmark))))
+$(foreach bmark,$(base_bmarks),$(eval $(call compile_template,$(bmark),$(RISCV_MARCH))))
+$(foreach bmark,$(vec_bmarks),$(eval $(call compile_template,$(bmark),$(RISCV_VMARCH))))
 
 #------------------------------------------------------------
 # Build and run benchmarks on riscv simulator


### PR DESCRIPTION
Autovectorizing for rv64gcv broke our smoke tests for non-V targets.