### PR TITLE
Fix rv64ua-amomaxu_w and rv64ua-amominu_w testcases

### DIFF
--- a/isa/rv64ua/amomaxu_w.S
+++ b/isa/rv64ua/amomaxu_w.S
@@ -31,6 +31,9 @@ RVTEST_CODE_BEGIN
 
   TEST_CASE(5, a5, 0xffffffffffffffff, lw a5, 0(a3))
 
+  # The following two cases check that the upper 32 bits are ignored on rv64
+  # implementations. Only enable them for rv64.
+  #if __riscv_xlen == 64
   TEST_CASE(6, a4, 1, \
     li a0, 0x0000000000000001; \
     li a1, 0x8000000000000000; \
@@ -40,6 +43,7 @@ RVTEST_CODE_BEGIN
   )
 
   TEST_CASE(7, a5, 1, lw a5, 0(a3))
+  #endif
 
   TEST_PASSFAIL
 

--- a/isa/rv64ua/amominu_w.S
+++ b/isa/rv64ua/amominu_w.S
@@ -31,6 +31,9 @@ RVTEST_CODE_BEGIN
 
   TEST_CASE(5, a5, 0, lw a5, 0(a3))
 
+  # The following two cases check that the upper 32 bits are ignored on rv64
+  # implementations. Only enable them for rv64.
+  #if __riscv_xlen == 64
   TEST_CASE(6, a4, 1, \
     li a0, 0x0000000000000001; \
     li a1, 0x8000000000000000; \
@@ -40,6 +43,7 @@ RVTEST_CODE_BEGIN
   )
 
   TEST_CASE(7, a5, 0, lw a5, 0(a3))
+  #endif
 
   TEST_PASSFAIL
 


### PR DESCRIPTION
When compiling the rv32ua tests, I stumbled across a compile error when using LLVM/clang. Test case 6 of both the [`rv64ua-amomaxu_w`](https://github.com/riscv-software-src/riscv-tests/blob/7785754f8f2811e691ec7c1e8f3683e1ed386006/isa/rv64ua/amomaxu_w.S#L34) and [`rv64ua-amominu_w`](https://github.com/riscv-software-src/riscv-tests/blob/7785754f8f2811e691ec7c1e8f3683e1ed386006/isa/rv64ua/amominu_w.S#L34) tests use a 64bit instead of a 32bit test value.
```
# from rv64ua-amomaxu_w
TEST_CASE(6, a4, 1, \
  li a0, 0x0000000000000001; \
  li a1, 0x8000000000000000; \  # <-- line of concern
  la a3, amo_operand; \
  sw a0, 0(a3); \
  amomaxu.w	a4, a1, 0(a3); \
)
```
Whereas gcc compiles successfully, it only takes the lower 32 bits into account and the actual value loaded into `a1` is zero. The actual test is still valid as the following test case 7 expects the `amomaxu_w` instruction to select zero as result. Clang cannot compile this code.

IMHO, this test case should check that the most negative number (all zeros except MSB = 1) is treated correctly as an unsigned value. This I assume due to the similarity of the signed counter part tests ([`rv64ua-amomax_w`](https://github.com/riscv-software-src/riscv-tests/blob/7785754f8f2811e691ec7c1e8f3683e1ed386006/isa/rv64ua/amomax_w.S#L34) and [`rv64ua-amomin_w`](https://github.com/riscv-software-src/riscv-tests/blob/7785754f8f2811e691ec7c1e8f3683e1ed386006/isa/rv64ua/amomin_w.S#L34)).

This PR corrects the "meaning" of the tests and also makes them clang compatible.
