### PR TITLE
Remove use of qNaN/sNaN to fix LLVM build

### DIFF
--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -417,11 +417,8 @@ test_ ## testnum: \
 # Tests floating-point instructions
 #-----------------------------------------------------------------------
 
-#define qNaNh 0h:7e00
 #define sNaNh 0h:7c01
-#define qNaNf 0f:7fc00000
 #define sNaNf 0f:7f800001
-#define qNaN 0d:7ff8000000000000
 #define sNaN 0d:7ff0000000000001
 
 #define TEST_FP_OP_H_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
@@ -574,8 +571,16 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, 0.0, \
                     inst f13, f10, f11; fmv.x.s a0, f13)
 
+#define TEST_FP_OP2_S_CNAN( testnum, inst, flags, val1, val2 ) \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, word 0x7fc00000, val1, val2, 0.0, \
+                    inst f13, f10, f11; fmv.x.s a0, f13)
+
 #define TEST_FP_OP2_H( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, val1, val2, 0.0, \
+                    inst f13, f10, f11; fmv.x.h a0, f13)
+
+#define TEST_FP_OP2_H_CNAN( testnum, inst, flags, val1, val2 ) \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, half 0x7e00, val1, val2, 0.0, \
                     inst f13, f10, f11; fmv.x.h a0, f13)
 
 #define TEST_FP_OP2_D32( testnum, inst, flags, result, val1, val2 ) \
@@ -583,8 +588,16 @@ test_ ## testnum: \
                     inst f13, f10, f11; fsd f13, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
 // ^: store computation result in address from a0, load high-word into t2
 
+#define TEST_FP_OP2_D32_CNAN( testnum, inst, flags, val1, val2 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword 0x7ff8000000000000, val1, val2, 0.0, \
+                    inst f13, f10, f11; fsd f13, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
+
 #define TEST_FP_OP2_D( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, val2, 0.0, \
+                    inst f13, f10, f11; fmv.x.d a0, f13)
+
+#define TEST_FP_OP2_D_CNAN( testnum, inst, flags, val1, val2 ) \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, dword 0x7ff8000000000000, val1, val2, 0.0, \
                     inst f13, f10, f11; fmv.x.d a0, f13)
 
 #define TEST_FP_OP3_S( testnum, inst, flags, result, val1, val2, val3 ) \

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -417,10 +417,6 @@ test_ ## testnum: \
 # Tests floating-point instructions
 #-----------------------------------------------------------------------
 
-#define sNaNh 0h:7c01
-#define sNaNf 0f:7f800001
-#define sNaN 0d:7ff0000000000001
-
 #define TEST_FP_OP_H_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
 test_ ## testnum: \
   li  TESTNUM, testnum; \

--- a/isa/rv64ud/fadd.S
+++ b/isa/rv64ud/fadd.S
@@ -17,6 +17,8 @@ RVTEST_CODE_BEGIN
     # Replace the function with the 32-bit variant defined in test_macros.h
     #undef TEST_FP_OP2_D
     #define TEST_FP_OP2_D TEST_FP_OP2_D32
+    #undef TEST_FP_OP2_D_CNAN
+    #define TEST_FP_OP2_D_CNAN TEST_FP_OP2_D32_CNAN
 #endif
 
   #-------------------------------------------------------------
@@ -36,7 +38,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_D(10,  fmul.d, 1,      3.14159265e-8, 3.14159265, 0.00000001 );
 
   # Is the canonical NaN generated for Inf - Inf?
-  TEST_FP_OP2_D(11,  fsub.d, 0x10, qNaN, Inf, Inf);
+  TEST_FP_OP2_D_CNAN(11,  fsub.d, 0x10, Inf, Inf);
 
   TEST_PASSFAIL
 

--- a/isa/rv64ud/fcmp.S
+++ b/isa/rv64ud/fcmp.S
@@ -34,15 +34,15 @@ RVTEST_CODE_BEGIN
   # Only sNaN should signal invalid for feq.
   TEST_FP_CMP_OP_D( 8, feq.d, 0x00, 0, NaN, 0)
   TEST_FP_CMP_OP_D( 9, feq.d, 0x00, 0, NaN, NaN)
-  TEST_FP_CMP_OP_D(10, feq.d, 0x10, 0, sNaN, 0)
+  TEST_FP_CMP_OP_D(10, feq.d, 0x10, 0, SNaN, 0)
 
   # qNaN should signal invalid for fle/flt.
   TEST_FP_CMP_OP_D(11, flt.d, 0x10, 0, NaN, 0)
   TEST_FP_CMP_OP_D(12, flt.d, 0x10, 0, NaN, NaN)
-  TEST_FP_CMP_OP_D(13, flt.d, 0x10, 0, sNaN, 0)
+  TEST_FP_CMP_OP_D(13, flt.d, 0x10, 0, SNaN, 0)
   TEST_FP_CMP_OP_D(14, fle.d, 0x10, 0, NaN, 0)
   TEST_FP_CMP_OP_D(15, fle.d, 0x10, 0, NaN, NaN)
-  TEST_FP_CMP_OP_D(16, fle.d, 0x10, 0, sNaN, 0)
+  TEST_FP_CMP_OP_D(16, fle.d, 0x10, 0, SNaN, 0)
 
   TEST_PASSFAIL
 

--- a/isa/rv64ud/fmin.S
+++ b/isa/rv64ud/fmin.S
@@ -40,7 +40,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_D(17,  fmax.d, 0,       -1.0,       -1.0,       -2.0 );
 
   # FMAX(sNaN, x) = x
-  TEST_FP_OP2_D(20,  fmax.d, 0x10, 1.0, sNaN, 1.0);
+  TEST_FP_OP2_D(20,  fmax.d, 0x10, 1.0, SNaN, 1.0);
   # FMAX(qNaN, qNaN) = canonical NaN
   TEST_FP_OP2_D_CNAN(21,  fmax.d, 0x00, NaN, NaN);
 

--- a/isa/rv64ud/fmin.S
+++ b/isa/rv64ud/fmin.S
@@ -17,6 +17,8 @@ RVTEST_CODE_BEGIN
     # Replace the function with the 32-bit variant defined in test_macros.h
     #undef TEST_FP_OP2_D
     #define TEST_FP_OP2_D TEST_FP_OP2_D32
+    #undef TEST_FP_OP2_D_CNAN
+    #define TEST_FP_OP2_D_CNAN TEST_FP_OP2_D32_CNAN
 #endif
 
   #-------------------------------------------------------------
@@ -40,7 +42,7 @@ RVTEST_CODE_BEGIN
   # FMAX(sNaN, x) = x
   TEST_FP_OP2_D(20,  fmax.d, 0x10, 1.0, sNaN, 1.0);
   # FMAX(qNaN, qNaN) = canonical NaN
-  TEST_FP_OP2_D(21,  fmax.d, 0x00, qNaN, NaN, NaN);
+  TEST_FP_OP2_D_CNAN(21,  fmax.d, 0x00, NaN, NaN);
 
   # -0.0 < +0.0
   TEST_FP_OP2_D(30,  fmin.d, 0,       -0.0,       -0.0,        0.0 );

--- a/isa/rv64uf/fadd.S
+++ b/isa/rv64uf/fadd.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_S(10,  fmul.s, 1,      3.14159265e-8, 3.14159265, 0.00000001 );
 
   # Is the canonical NaN generated for Inf - Inf?
-  TEST_FP_OP2_S(11,  fsub.s, 0x10, qNaNf, Inf, Inf);
+  TEST_FP_OP2_S_CNAN(11,  fsub.s, 0x10, Inf, Inf);
 
   TEST_PASSFAIL
 

--- a/isa/rv64uf/fcmp.S
+++ b/isa/rv64uf/fcmp.S
@@ -28,15 +28,15 @@ RVTEST_CODE_BEGIN
   # Only sNaN should signal invalid for feq.
   TEST_FP_CMP_OP_S( 8, feq.s, 0x00, 0, NaN, 0)
   TEST_FP_CMP_OP_S( 9, feq.s, 0x00, 0, NaN, NaN)
-  TEST_FP_CMP_OP_S(10, feq.s, 0x10, 0, sNaNf, 0)
+  TEST_FP_CMP_OP_S(10, feq.s, 0x10, 0, SNaN, 0)
 
   # qNaN should signal invalid for fle/flt.
   TEST_FP_CMP_OP_S(11, flt.s, 0x10, 0, NaN, 0)
   TEST_FP_CMP_OP_S(12, flt.s, 0x10, 0, NaN, NaN)
-  TEST_FP_CMP_OP_S(13, flt.s, 0x10, 0, sNaNf, 0)
+  TEST_FP_CMP_OP_S(13, flt.s, 0x10, 0, SNaN, 0)
   TEST_FP_CMP_OP_S(14, fle.s, 0x10, 0, NaN, 0)
   TEST_FP_CMP_OP_S(15, fle.s, 0x10, 0, NaN, NaN)
-  TEST_FP_CMP_OP_S(16, fle.s, 0x10, 0, sNaNf, 0)
+  TEST_FP_CMP_OP_S(16, fle.s, 0x10, 0, SNaN, 0)
 
   TEST_PASSFAIL
 

--- a/isa/rv64uf/fmin.S
+++ b/isa/rv64uf/fmin.S
@@ -34,7 +34,7 @@ RVTEST_CODE_BEGIN
   # FMAX(sNaN, x) = x
   TEST_FP_OP2_S(20,  fmax.s, 0x10, 1.0, sNaNf, 1.0);
   # FMAX(qNaN, qNaN) = canonical NaN
-  TEST_FP_OP2_S(21,  fmax.s, 0x00, qNaNf, NaN, NaN);
+  TEST_FP_OP2_S_CNAN(21,  fmax.s, 0x00, NaN, NaN);
 
   # -0.0 < +0.0
   TEST_FP_OP2_S(30,  fmin.s, 0,       -0.0,       -0.0,        0.0 );

--- a/isa/rv64uf/fmin.S
+++ b/isa/rv64uf/fmin.S
@@ -32,7 +32,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_S(17,  fmax.s, 0,       -1.0,       -1.0,       -2.0 );
 
   # FMAX(sNaN, x) = x
-  TEST_FP_OP2_S(20,  fmax.s, 0x10, 1.0, sNaNf, 1.0);
+  TEST_FP_OP2_S(20,  fmax.s, 0x10, 1.0, SNaN, 1.0);
   # FMAX(qNaN, qNaN) = canonical NaN
   TEST_FP_OP2_S_CNAN(21,  fmax.s, 0x00, NaN, NaN);
 

--- a/isa/rv64uzfh/fadd.S
+++ b/isa/rv64uzfh/fadd.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_H(10,  fmul.h, 1,                 1.1,      11.0,        0.1 );
 
   # Is the canonical NaN generated for Inf - Inf?
-  TEST_FP_OP2_H(11,  fsub.h, 0x10, qNaNh, Inf, Inf);
+  TEST_FP_OP2_H_CNAN(11,  fsub.h, 0x10, Inf, Inf);
 
   TEST_PASSFAIL
 

--- a/isa/rv64uzfh/fmin.S
+++ b/isa/rv64uzfh/fmin.S
@@ -34,7 +34,7 @@ RVTEST_CODE_BEGIN
   # FMIN(hNaN, x) = x
   TEST_FP_OP2_H(20,  fmax.h, 0x10, 1.0, sNaNh, 1.0);
   # FMIN(hNaN, hNaN) = canonical NaN
-  TEST_FP_OP2_H(21,  fmax.h, 0x00, qNaNh, NaN, NaN);
+  TEST_FP_OP2_H_CNAN(21,  fmax.h, 0x00, NaN, NaN);
 
   # -0.0 < +0.0
   TEST_FP_OP2_H(30,  fmin.h, 0,       -0.0,       -0.0,        0.0 );

--- a/isa/rv64uzfh/fmin.S
+++ b/isa/rv64uzfh/fmin.S
@@ -32,7 +32,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_H(17,  fmax.h, 0,       -1.0,       -1.0,       -2.0 );
 
   # FMIN(hNaN, x) = x
-  TEST_FP_OP2_H(20,  fmax.h, 0x10, 1.0, sNaNh, 1.0);
+  TEST_FP_OP2_H(20,  fmax.h, 0x10, 1.0, SNaN, 1.0);
   # FMIN(hNaN, hNaN) = canonical NaN
   TEST_FP_OP2_H_CNAN(21,  fmax.h, 0x00, NaN, NaN);
 


### PR DESCRIPTION
Resolves #610 