### PR TITLE
Remove use of qNaN/sNaN in a different way to fix LLVM build

### DIFF
--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -633,16 +633,32 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, word result, float val1, float val2, float 0, \
                     inst a0, f10, f11)
 
+#define TEST_FP_CMP_OP_S_HEX( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, word result, word val1, word val2, float 0, \
+                    inst a0, f10, f11)
+
 #define TEST_FP_CMP_OP_H( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_H_INTERNAL( testnum, flags, hword result, float16 val1, float16 val2, float16 0, \
+                    inst a0, f10, f11)
+
+#define TEST_FP_CMP_OP_H_HEX( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, hword result, half val1, half val2, float16 0, \
                     inst a0, f10, f11)
 
 #define TEST_FP_CMP_OP_D32( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, double val1, double val2, double 0, \
                     inst a0, f10, f11; li t2, 0)
 
+#define TEST_FP_CMP_OP_D32_HEX( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, dword val1, dword val2, double 0, \
+                    inst a0, f10, f11; li t2, 0)
+
 #define TEST_FP_CMP_OP_D( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, double val1, double val2, double 0, \
+                    inst a0, f10, f11)
+
+#define TEST_FP_CMP_OP_D_HEX( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, dword val1, dword val2, double 0, \
                     inst a0, f10, f11)
 
 #define TEST_FCLASS_S(testnum, correct, input) \

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -433,9 +433,9 @@ test_ ## testnum: \
   .pushsection .data; \
   .align 1; \
   test_ ## testnum ## _data: \
-  .float16 val1; \
-  .float16 val2; \
-  .float16 val3; \
+  .val1; \
+  .val2; \
+  .val3; \
   .result; \
   .popsection
 
@@ -455,9 +455,9 @@ test_ ## testnum: \
   .pushsection .data; \
   .align 2; \
   test_ ## testnum ## _data: \
-  .float val1; \
-  .float val2; \
-  .float val3; \
+  .val1; \
+  .val2; \
+  .val3; \
   .result; \
   .popsection
 
@@ -477,9 +477,9 @@ test_ ## testnum: \
   .pushsection .data; \
   .align 3; \
   test_ ## testnum ## _data: \
-  .double val1; \
-  .double val2; \
-  .double val3; \
+  .val1; \
+  .val2; \
+  .val3; \
   .result; \
   .popsection
 
@@ -502,147 +502,147 @@ test_ ## testnum: \
   .pushsection .data; \
   .align 3; \
   test_ ## testnum ## _data: \
-  .double val1; \
-  .double val2; \
-  .double val3; \
+  .val1; \
+  .val2; \
+  .val3; \
   .result; \
   .popsection
 
 #define TEST_FCVT_S_D32( testnum, result, val1 ) \
-  TEST_FP_OP_D32_INTERNAL( testnum, 0, double result, val1, 0.0, 0.0, \
+  TEST_FP_OP_D32_INTERNAL( testnum, 0, double result, double val1, double 0, double 0, \
                     fcvt.s.d f13, f10; fcvt.d.s f13, f13; fsd f13, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
 
 #define TEST_FCVT_S_D( testnum, result, val1 ) \
-  TEST_FP_OP_D_INTERNAL( testnum, 0, double result, val1, 0.0, 0.0, \
+  TEST_FP_OP_D_INTERNAL( testnum, 0, double result, double val1, double 0, double 0, \
                     fcvt.s.d f13, f10; fcvt.d.s f13, f13; fmv.x.d a0, f13)
 
 #define TEST_FCVT_D_S( testnum, result, val1 ) \
-  TEST_FP_OP_S_INTERNAL( testnum, 0, float result, val1, 0.0, 0.0, \
+  TEST_FP_OP_S_INTERNAL( testnum, 0, float result, float val1, float 0, float 0, \
                     fcvt.d.s f13, f10; fcvt.s.d f13, f13; fmv.x.s a0, f13)
 
 #define TEST_FCVT_H_S( testnum, result, val1 ) \
-  TEST_FP_OP_H_INTERNAL( testnum, 0, float16 result, val1, 0.0, 0.0, \
+  TEST_FP_OP_H_INTERNAL( testnum, 0, float16 result, float16 val1, float16 0, float16 0, \
                     fcvt.s.h f13, f10; fcvt.h.s f13, f13; fmv.x.h a0, f13)
 
 #define TEST_FCVT_H_D( testnum, result, val1 ) \
-  TEST_FP_OP_H_INTERNAL( testnum, 0, float16 result, val1, 0.0, 0.0, \
+  TEST_FP_OP_H_INTERNAL( testnum, 0, float16 result, float16 val1, float16 0, float16 0, \
                     fcvt.d.h f13, f10; fcvt.h.d f13, f13; fmv.x.h a0, f13)
 
 
 #define TEST_FP_OP1_H( testnum, inst, flags, result, val1 ) \
-  TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, val1, 0.0, 0.0, \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, float16 val1, float16 0, float16 0, \
                     inst f13, f10; fmv.x.h a0, f13;)
 
 #define TEST_FP_OP1_S( testnum, inst, flags, result, val1 ) \
-  TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, 0.0, 0.0, \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, float result, float val1, float 0, float 0, \
                     inst f13, f10; fmv.x.s a0, f13)
 
 #define TEST_FP_OP1_D32( testnum, inst, flags, result, val1 ) \
-  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, 0.0, 0.0, \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, double val1, double 0, double 0, \
                     inst f13, f10; fsd f13, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
 // ^: store computation result in address from a0, load high-word into t2
 
 #define TEST_FP_OP1_D( testnum, inst, flags, result, val1 ) \
-  TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, 0.0, 0.0, \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, double result, double val1, double 0, double 0, \
                     inst f13, f10; fmv.x.d a0, f13)
 
 #define TEST_FP_OP1_S_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
-  TEST_FP_OP_S_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, dword result, float val1, float 0, float 0, \
                     inst f13, f10; fmv.x.s a0, f13)
 
 #define TEST_FP_OP1_H_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
-  TEST_FP_OP_H_INTERNAL( testnum, flags, word result, val1, 0.0, 0.0, \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, word result, float16 val1, float16 0, float16 0, \
                     inst f13, f10; fmv.x.h a0, f13)
 
 #define TEST_FP_OP1_D32_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
-  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, double val1, double 0, double 0, \
                     inst f13, f10; fsd f13, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
 // ^: store computation result in address from a0, load high-word into t2
 
 #define TEST_FP_OP1_D_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
-  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, double val1, double 0, double 0, \
                     inst f13, f10; fmv.x.d a0, f13)
 
 #define TEST_FP_OP2_S( testnum, inst, flags, result, val1, val2 ) \
-  TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, 0.0, \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, float result, float val1, float val2, float 0, \
                     inst f13, f10, f11; fmv.x.s a0, f13)
 
-#define TEST_FP_OP2_S_CNAN( testnum, inst, flags, val1, val2 ) \
-  TEST_FP_OP_S_INTERNAL( testnum, flags, word 0x7fc00000, val1, val2, 0.0, \
+#define TEST_FP_OP2_S_HEX( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, word result, word val1, word val2, float 0, \
                     inst f13, f10, f11; fmv.x.s a0, f13)
 
 #define TEST_FP_OP2_H( testnum, inst, flags, result, val1, val2 ) \
-  TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, val1, val2, 0.0, \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, float16 val1, float16 val2, float16 0, \
                     inst f13, f10, f11; fmv.x.h a0, f13)
 
-#define TEST_FP_OP2_H_CNAN( testnum, inst, flags, val1, val2 ) \
-  TEST_FP_OP_H_INTERNAL( testnum, flags, half 0x7e00, val1, val2, 0.0, \
+#define TEST_FP_OP2_H_HEX( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, half result, half val1, half val2, float16 0, \
                     inst f13, f10, f11; fmv.x.h a0, f13)
 
 #define TEST_FP_OP2_D32( testnum, inst, flags, result, val1, val2 ) \
-  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, val2, 0.0, \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, double val1, double val2, double 0, \
                     inst f13, f10, f11; fsd f13, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
 // ^: store computation result in address from a0, load high-word into t2
 
-#define TEST_FP_OP2_D32_CNAN( testnum, inst, flags, val1, val2 ) \
-  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword 0x7ff8000000000000, val1, val2, 0.0, \
+#define TEST_FP_OP2_D32_HEX( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, dword val1, dword val2, double 0, \
                     inst f13, f10, f11; fsd f13, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
 
 #define TEST_FP_OP2_D( testnum, inst, flags, result, val1, val2 ) \
-  TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, val2, 0.0, \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, double result, double val1, double val2, double 0, \
                     inst f13, f10, f11; fmv.x.d a0, f13)
 
-#define TEST_FP_OP2_D_CNAN( testnum, inst, flags, val1, val2 ) \
-  TEST_FP_OP_D_INTERNAL( testnum, flags, dword 0x7ff8000000000000, val1, val2, 0.0, \
+#define TEST_FP_OP2_D_HEX( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, dword val1, dword val2, double 0, \
                     inst f13, f10, f11; fmv.x.d a0, f13)
 
 #define TEST_FP_OP3_S( testnum, inst, flags, result, val1, val2, val3 ) \
-  TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, val3, \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, float result, float val1, float val2, float val3, \
                     inst f13, f10, f11, f12; fmv.x.s a0, f13)
 
 #define TEST_FP_OP3_H( testnum, inst, flags, result, val1, val2, val3 ) \
-  TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, val1, val2, val3, \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, float16 result, float16 val1, float16 val2, float16 val3, \
                     inst f13, f10, f11, f12; fmv.x.h a0, f13)
 
 #define TEST_FP_OP3_D32( testnum, inst, flags, result, val1, val2, val3 ) \
-  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, val2, val3, \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, double val1, double val2, double val3, \
                     inst f13, f10, f11, f12; fsd f13, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
 // ^: store computation result in address from a0, load high-word into t2
 
 #define TEST_FP_OP3_D( testnum, inst, flags, result, val1, val2, val3 ) \
-  TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, val2, val3, \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, double result, double val1, double val2, double val3, \
                     inst f13, f10, f11, f12; fmv.x.d a0, f13)
 
 #define TEST_FP_INT_OP_S( testnum, inst, flags, result, val1, rm ) \
-  TEST_FP_OP_S_INTERNAL( testnum, flags, word result, val1, 0.0, 0.0, \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, word result, float val1, float 0, float 0, \
                     inst a0, f10, rm)
 
 #define TEST_FP_INT_OP_H( testnum, inst, flags, result, val1, rm ) \
-  TEST_FP_OP_H_INTERNAL( testnum, flags, word result, val1, 0.0, 0.0, \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, word result, float16 val1, float16 0, float16 0, \
                     inst a0, f10, rm)
 
 #define TEST_FP_INT_OP_D32( testnum, inst, flags, result, val1, rm ) \
-  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, double val1, double 0, double 0, \
                     inst a0, f10, f11; li t2, 0)
 
 #define TEST_FP_INT_OP_D( testnum, inst, flags, result, val1, rm ) \
-  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, double val1, double 0, double 0, \
                     inst a0, f10, rm)
 
 #define TEST_FP_CMP_OP_S( testnum, inst, flags, result, val1, val2 ) \
-  TEST_FP_OP_S_INTERNAL( testnum, flags, word result, val1, val2, 0.0, \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, word result, float val1, float val2, float 0, \
                     inst a0, f10, f11)
 
 #define TEST_FP_CMP_OP_H( testnum, inst, flags, result, val1, val2 ) \
-  TEST_FP_OP_H_INTERNAL( testnum, flags, hword result, val1, val2, 0.0, \
+  TEST_FP_OP_H_INTERNAL( testnum, flags, hword result, float16 val1, float16 val2, float16 0, \
                     inst a0, f10, f11)
 
 #define TEST_FP_CMP_OP_D32( testnum, inst, flags, result, val1, val2 ) \
-  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, val1, val2, 0.0, \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, double val1, double val2, double 0, \
                     inst a0, f10, f11; li t2, 0)
 
 #define TEST_FP_CMP_OP_D( testnum, inst, flags, result, val1, val2 ) \
-  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, val2, 0.0, \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, double val1, double val2, double 0, \
                     inst a0, f10, f11)
 
 #define TEST_FCLASS_S(testnum, correct, input) \

--- a/isa/rv64ud/fadd.S
+++ b/isa/rv64ud/fadd.S
@@ -17,8 +17,8 @@ RVTEST_CODE_BEGIN
     # Replace the function with the 32-bit variant defined in test_macros.h
     #undef TEST_FP_OP2_D
     #define TEST_FP_OP2_D TEST_FP_OP2_D32
-    #undef TEST_FP_OP2_D_CNAN
-    #define TEST_FP_OP2_D_CNAN TEST_FP_OP2_D32_CNAN
+    #undef TEST_FP_OP2_D_HEX
+    #define TEST_FP_OP2_D_HEX TEST_FP_OP2_D32_HEX
 #endif
 
   #-------------------------------------------------------------
@@ -38,7 +38,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_D(10,  fmul.d, 1,      3.14159265e-8, 3.14159265, 0.00000001 );
 
   # Is the canonical NaN generated for Inf - Inf?
-  TEST_FP_OP2_D_CNAN(11,  fsub.d, 0x10, Inf, Inf);
+  TEST_FP_OP2_D_HEX(11,  fsub.d, 0x10, 0x7ff8000000000000, 0x7ff0000000000000, 0x7ff0000000000000);
 
   TEST_PASSFAIL
 

--- a/isa/rv64ud/fcmp.S
+++ b/isa/rv64ud/fcmp.S
@@ -21,6 +21,8 @@ RVTEST_CODE_BEGIN
     # Replace the function with the 32-bit variant defined in test_macros.h
     #undef TEST_FP_CMP_OP_D
     #define TEST_FP_CMP_OP_D TEST_FP_CMP_OP_D32
+    #undef TEST_FP_CMP_OP_D_HEX
+    #define TEST_FP_CMP_OP_D_HEX TEST_FP_CMP_OP_D32_HEX
 #endif
 
   TEST_FP_CMP_OP_D( 2, feq.d, 0x00, 1, -1.36, -1.36)
@@ -34,15 +36,15 @@ RVTEST_CODE_BEGIN
   # Only sNaN should signal invalid for feq.
   TEST_FP_CMP_OP_D( 8, feq.d, 0x00, 0, NaN, 0)
   TEST_FP_CMP_OP_D( 9, feq.d, 0x00, 0, NaN, NaN)
-  TEST_FP_CMP_OP_D(10, feq.d, 0x10, 0, SNaN, 0)
+  TEST_FP_CMP_OP_D_HEX(10, feq.d, 0x10, 0, 0x7ff0000000000001, 0)
 
   # qNaN should signal invalid for fle/flt.
   TEST_FP_CMP_OP_D(11, flt.d, 0x10, 0, NaN, 0)
   TEST_FP_CMP_OP_D(12, flt.d, 0x10, 0, NaN, NaN)
-  TEST_FP_CMP_OP_D(13, flt.d, 0x10, 0, SNaN, 0)
+  TEST_FP_CMP_OP_D_HEX(13, flt.d, 0x10, 0, 0x7ff0000000000001, 0)
   TEST_FP_CMP_OP_D(14, fle.d, 0x10, 0, NaN, 0)
   TEST_FP_CMP_OP_D(15, fle.d, 0x10, 0, NaN, NaN)
-  TEST_FP_CMP_OP_D(16, fle.d, 0x10, 0, SNaN, 0)
+  TEST_FP_CMP_OP_D_HEX(16, fle.d, 0x10, 0, 0x7ff0000000000001, 0)
 
   TEST_PASSFAIL
 

--- a/isa/rv64ud/fmin.S
+++ b/isa/rv64ud/fmin.S
@@ -17,8 +17,8 @@ RVTEST_CODE_BEGIN
     # Replace the function with the 32-bit variant defined in test_macros.h
     #undef TEST_FP_OP2_D
     #define TEST_FP_OP2_D TEST_FP_OP2_D32
-    #undef TEST_FP_OP2_D_CNAN
-    #define TEST_FP_OP2_D_CNAN TEST_FP_OP2_D32_CNAN
+    #undef TEST_FP_OP2_D_HEX
+    #define TEST_FP_OP2_D_HEX TEST_FP_OP2_D32_HEX
 #endif
 
   #-------------------------------------------------------------
@@ -42,7 +42,7 @@ RVTEST_CODE_BEGIN
   # FMAX(sNaN, x) = x
   TEST_FP_OP2_D(20,  fmax.d, 0x10, 1.0, SNaN, 1.0);
   # FMAX(qNaN, qNaN) = canonical NaN
-  TEST_FP_OP2_D_CNAN(21,  fmax.d, 0x00, NaN, NaN);
+  TEST_FP_OP2_D_HEX(21,  fmax.d, 0x00, 0x7ff8000000000000, 0x7fffffffffffffff, 0x7fffffffffffffff);
 
   # -0.0 < +0.0
   TEST_FP_OP2_D(30,  fmin.d, 0,       -0.0,       -0.0,        0.0 );

--- a/isa/rv64ud/fmin.S
+++ b/isa/rv64ud/fmin.S
@@ -40,7 +40,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_D(17,  fmax.d, 0,       -1.0,       -1.0,       -2.0 );
 
   # FMAX(sNaN, x) = x
-  TEST_FP_OP2_D(20,  fmax.d, 0x10, 1.0, SNaN, 1.0);
+  TEST_FP_OP2_D_HEX(20,  fmax.d, 0x10, 0x3ff0000000000000, 0x7ff0000000000001, 0x3ff0000000000000);
   # FMAX(qNaN, qNaN) = canonical NaN
   TEST_FP_OP2_D_HEX(21,  fmax.d, 0x00, 0x7ff8000000000000, 0x7fffffffffffffff, 0x7fffffffffffffff);
 

--- a/isa/rv64uf/fadd.S
+++ b/isa/rv64uf/fadd.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_S(10,  fmul.s, 1,      3.14159265e-8, 3.14159265, 0.00000001 );
 
   # Is the canonical NaN generated for Inf - Inf?
-  TEST_FP_OP2_S_CNAN(11,  fsub.s, 0x10, Inf, Inf);
+  TEST_FP_OP2_S_HEX(11,  fsub.s, 0x10, 0x7fc00000, 0x7f800000, 0x7f800000);
 
   TEST_PASSFAIL
 

--- a/isa/rv64uf/fcmp.S
+++ b/isa/rv64uf/fcmp.S
@@ -28,15 +28,15 @@ RVTEST_CODE_BEGIN
   # Only sNaN should signal invalid for feq.
   TEST_FP_CMP_OP_S( 8, feq.s, 0x00, 0, NaN, 0)
   TEST_FP_CMP_OP_S( 9, feq.s, 0x00, 0, NaN, NaN)
-  TEST_FP_CMP_OP_S(10, feq.s, 0x10, 0, SNaN, 0)
+  TEST_FP_CMP_OP_S_HEX(10, feq.s, 0x10, 0, 0x7f800001, 0)
 
   # qNaN should signal invalid for fle/flt.
   TEST_FP_CMP_OP_S(11, flt.s, 0x10, 0, NaN, 0)
   TEST_FP_CMP_OP_S(12, flt.s, 0x10, 0, NaN, NaN)
-  TEST_FP_CMP_OP_S(13, flt.s, 0x10, 0, SNaN, 0)
+  TEST_FP_CMP_OP_S_HEX(13, flt.s, 0x10, 0, 0x7f800001, 0)
   TEST_FP_CMP_OP_S(14, fle.s, 0x10, 0, NaN, 0)
   TEST_FP_CMP_OP_S(15, fle.s, 0x10, 0, NaN, NaN)
-  TEST_FP_CMP_OP_S(16, fle.s, 0x10, 0, SNaN, 0)
+  TEST_FP_CMP_OP_S_HEX(16, fle.s, 0x10, 0, 0x7f800001, 0)
 
   TEST_PASSFAIL
 

--- a/isa/rv64uf/fmin.S
+++ b/isa/rv64uf/fmin.S
@@ -34,7 +34,7 @@ RVTEST_CODE_BEGIN
   # FMAX(sNaN, x) = x
   TEST_FP_OP2_S(20,  fmax.s, 0x10, 1.0, SNaN, 1.0);
   # FMAX(qNaN, qNaN) = canonical NaN
-  TEST_FP_OP2_S_CNAN(21,  fmax.s, 0x00, NaN, NaN);
+  TEST_FP_OP2_S_HEX(21,  fmax.s, 0x00, 0x7fc00000, 0x7fffffff, 0x7fffffff);
 
   # -0.0 < +0.0
   TEST_FP_OP2_S(30,  fmin.s, 0,       -0.0,       -0.0,        0.0 );

--- a/isa/rv64uf/fmin.S
+++ b/isa/rv64uf/fmin.S
@@ -32,7 +32,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_S(17,  fmax.s, 0,       -1.0,       -1.0,       -2.0 );
 
   # FMAX(sNaN, x) = x
-  TEST_FP_OP2_S(20,  fmax.s, 0x10, 1.0, SNaN, 1.0);
+  TEST_FP_OP2_S_HEX(20,  fmax.s, 0x10, 0x3f800000, 0x7f800001, 0x3f800000);
   # FMAX(qNaN, qNaN) = canonical NaN
   TEST_FP_OP2_S_HEX(21,  fmax.s, 0x00, 0x7fc00000, 0x7fffffff, 0x7fffffff);
 

--- a/isa/rv64uzfh/fadd.S
+++ b/isa/rv64uzfh/fadd.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_H(10,  fmul.h, 1,                 1.1,      11.0,        0.1 );
 
   # Is the canonical NaN generated for Inf - Inf?
-  TEST_FP_OP2_H_CNAN(11,  fsub.h, 0x10, Inf, Inf);
+  TEST_FP_OP2_H_HEX(11,  fsub.h, 0x10, 0x7e00, 0x7c00, 0x7c00);
 
   TEST_PASSFAIL
 

--- a/isa/rv64uzfh/fmin.S
+++ b/isa/rv64uzfh/fmin.S
@@ -34,7 +34,7 @@ RVTEST_CODE_BEGIN
   # FMIN(hNaN, x) = x
   TEST_FP_OP2_H(20,  fmax.h, 0x10, 1.0, SNaN, 1.0);
   # FMIN(hNaN, hNaN) = canonical NaN
-  TEST_FP_OP2_H_CNAN(21,  fmax.h, 0x00, NaN, NaN);
+  TEST_FP_OP2_H_HEX(21,  fmax.h, 0x00, 0x7e00, 0x7fff, 0x7fff);
 
   # -0.0 < +0.0
   TEST_FP_OP2_H(30,  fmin.h, 0,       -0.0,       -0.0,        0.0 );

--- a/isa/rv64uzfh/fmin.S
+++ b/isa/rv64uzfh/fmin.S
@@ -31,8 +31,8 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP2_H(16,  fmax.h, 0, 3.14159265, 3.14159265, 0.00000001 );
   TEST_FP_OP2_H(17,  fmax.h, 0,       -1.0,       -1.0,       -2.0 );
 
-  # FMIN(hNaN, x) = x
-  TEST_FP_OP2_H(20,  fmax.h, 0x10, 1.0, SNaN, 1.0);
+  # FMIN(sNaN, x) = x
+  TEST_FP_OP2_H_HEX(20,  fmax.h, 0x10, 0x3c00, 0x7c01, 0x3c00);
   # FMIN(hNaN, hNaN) = canonical NaN
   TEST_FP_OP2_H_HEX(21,  fmax.h, 0x00, 0x7e00, 0x7fff, 0x7fff);
 


### PR DESCRIPTION
Revises #612.