### PR TITLE
[debug] enhance set_pmp_deny to support alignment checks

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -276,11 +276,13 @@ class MemTest64(SimpleMemoryTest):
         self.access_test(8, 'long long')
 
 class MemTestReadInvalid(SimpleMemoryTest):
+    def early_applicable(self):
+        return self.target.support_set_pmp_deny
+
     def test(self):
         bad_address = self.hart.bad_address
-        if self.target.support_set_pmp_deny:
-            self.set_pmp_deny(bad_address)
-            self.gdb.command("monitor riscv set_mem_access progbuf abstract")
+        self.set_pmp_deny(bad_address, 4)
+        self.gdb.command("monitor riscv set_mem_access progbuf abstract")
         good_address = self.hart.ram + 0x80
 
         self.write_nop_program(2)
@@ -296,10 +298,9 @@ class MemTestReadInvalid(SimpleMemoryTest):
         self.gdb.stepi()    # Don't let gdb cache register read
         assertEqual(self.gdb.p(f"*((int*)0x{good_address:x})"), 0xabcdef)
         assertEqual(self.gdb.p("$s0"), 0x12345678)
-        if self.target.support_set_pmp_deny:
-            self.reset_pmp_deny()
-            self.gdb.command("monitor riscv set_mem_access progbuf sysbus "
-                             "abstract")
+        self.reset_pmp_deny()
+        self.gdb.command("monitor riscv set_mem_access progbuf sysbus "
+                         "abstract")
 
 #class MemTestWriteInvalid(SimpleMemoryTest):
 #    def test(self):
@@ -2200,7 +2201,7 @@ class EtriggerTest(DebugTest):
     # TODO: There should be a check that a exception trigger is really not
     # supported if it is marked as unsupported.
     def early_applicable(self):
-        return self.target.support_etrigger
+        return self.target.support_etrigger and self.target.support_set_pmp_deny
 
     def setup(self):
         DebugTest.setup(self)
@@ -2214,9 +2215,8 @@ class EtriggerTest(DebugTest):
         # Set fox to a bad pointer so we'll get a load access exception later.
         # Use NULL if a known-bad address is not provided.
         bad_address = self.hart.bad_address or 0
-        if self.target.support_set_pmp_deny:
-            self.set_pmp_deny(bad_address)
-            self.gdb.command("monitor riscv set_mem_access progbuf abstract")
+        self.set_pmp_deny(bad_address, 1)
+        self.gdb.command("monitor riscv set_mem_access progbuf abstract")
         self.gdb.p(f"fox=(char*)0x{bad_address:08x}")
         output = self.gdb.c()
         # We should not be at handle_trap
@@ -2225,10 +2225,9 @@ class EtriggerTest(DebugTest):
         # actual exception handler.
         assertIn("breakpoint", output)
         assertIn("trap_entry", self.gdb.where())
-        if self.target.support_set_pmp_deny:
-            self.reset_pmp_deny()
-            self.gdb.command("monitor riscv set_mem_access progbuf sysbus "
-                             "abstract")
+        self.reset_pmp_deny()
+        self.gdb.command("monitor riscv set_mem_access progbuf sysbus "
+                         "abstract")
 
 class IcountTest(DebugTest):
     compile_args = ("programs/infinite_loop.S", )

--- a/debug/targets.py
+++ b/debug/targets.py
@@ -148,6 +148,9 @@ class Target:
     # Support set_pmp_deny to create invalid addresses.
     support_set_pmp_deny = False
 
+    # Minimum PMP granularity supported by the target, in bytes.
+    minimum_pmp_granularity = 4
+
     # Supports an address/data match trigger of type 2
     support_mcontrol = True
 


### PR DESCRIPTION
This PR sets the NAPOT range size considering the minimum PMP granularity supported by the hart.

This PR is separate from #632 as suggested by @en-sc .

## The issue this PR solves.

- `set_pmp_deny()` is called by two tests, `MemTestReadInvalid()` and `EtriggerTest()`, with the argument `bad_address`.
- The default value of `size` for `set_pmp_deny()` is 4 KB.
- `MemTestReadInvalid()` requires 4 bytes and `EtriggerTest()` requires 1 byte for `size`, but they use the default value (4 KB).
- From `debug/targets/RISC-V/spike32.py` and `debug/targets/RISC-V/spike64.py`:

```python
    ram = 0x1010_0000      // '_' is added
   ...
    bad_address = ram - 8  // 0x100f_fff8
```

- From `testlib.py` L1496

```python
        self.gdb.p("$pmpaddr0="
                       f"0x{((address >> 2) | ((size - 1) >> 3)):x}")
```

`pmpaddr0` is set to `0x100f_ffff >> 2` (1MB NAPOT range starting 0x1000_0000).

## How this PR works

- The argument `size` of `set_pmp_deny()` now has no default value.  The caller sets it to the value required by the test.
- The NAPOT range size is calculated as the minimum size required by the `size` argument and the minimum supported PMP granularity.
- `set_pmp_deny()` raises a `TestNotApplicable` error if the value of the argument `address` is inconsistent with the calculated size. This error allows users to set `bad_address` to a proper value.


